### PR TITLE
feat: use client registration token for ndt7 tests

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: npm install -g yarn && yarn install --frozen-lockfile && yarn build
+      - name: Substitute M-Lab project placeholder
+        run: sed -i 's/MLAB_PROJECT_PLACEHOLDER/mlab-oti/g' app/measure/measure.js
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'

--- a/README.md
+++ b/README.md
@@ -39,3 +39,14 @@ To preview the site locally, we recommend using the Python Simple HTTP Server.
 * Navigate to the `/app` directory and run: `python3 -m http.server 8000`
 
 If you are a user on the M-Lab Firebase project, you can also preview the site locally using the firebase-cli: `firebase serve --only hosting:mlab-speedtest`
+
+## Deployment
+
+The site is deployed via GitHub Actions to Firebase Hosting:
+
+| Environment | Trigger                       | URL                              |
+|-------------|-------------------------------|----------------------------------|
+| Sandbox     | Pull request (from same repo) | https://mlab-sandbox.web.app     |
+| Production  | Merge to `main`               | https://speed.measurementlab.net |
+
+**Note:** PR deployments only work for branches pushed directly to `m-lab/mlab-speedtest`, not from forks (due to Firebase secrets not being available to fork PRs).


### PR DESCRIPTION
Update ndt7-js to 0.1.3 which supports the `clientRegistrationToken`
option. Before running ndt7 tests, fetch a short-lived JWT token from
the speed-backend service which enables priority access to the Locate
API for registered integrations.

This is the first step toward using the client registration system
for M-Lab's speed test website along with the new backend that we
have written for this purpose: https://github.com/m-lab/speed-proxy.

We implement an open failure model where failure to get the token
causes ndt7 to avoid using the client-integration code.

We use `mlab-staging` as the default when the placeholder is not
substituted (local development and PR previews), so we always know
which `m-lab/speed-proxy` commit we're testing against. Only the
production merge workflow substitutes the placeholder with `mlab-oti`.

Also, update `yarn.lock`.

Also, make sure we use correct permissions for GitHub actions.

Also, mention deployment location in the `README.md`.