### PR TITLE
fix: defer Scrollex initialization until AngularJS renders sections 

### DIFF
--- a/app/assets/js/main.js
+++ b/app/assets/js/main.js
@@ -4,206 +4,228 @@
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 */
 
-(function($) {
+(function ($) {
 
 	skel.breakpoints({
-		xlarge:	'(max-width: 1680px)',
-		large:	'(max-width: 1280px)',
-		medium:	'(max-width: 980px)',
-		small:	'(max-width: 736px)',
-		xsmall:	'(max-width: 480px)'
+		xlarge: '(max-width: 1680px)',
+		large: '(max-width: 1280px)',
+		medium: '(max-width: 980px)',
+		small: '(max-width: 736px)',
+		xsmall: '(max-width: 480px)'
 	});
 
-	$(function() {
+	$(function () {
 
-		var	$window = $(window),
+		var $window = $(window),
 			$body = $('body'),
 			$sidebar = $('#sidebar');
 
 		// Hack: Enable IE flexbox workarounds.
-			if (skel.vars.IEVersion < 12)
-				$body.addClass('is-ie');
+		if (skel.vars.IEVersion < 12)
+			$body.addClass('is-ie');
 
 		// Disable animations/transitions until the page has loaded.
-			// if (skel.canUse('transition'))
-			// 	$body.addClass('is-loading');
-			//
-			// $window.on('load', function() {
-			// 	window.setTimeout(function() {
-			// 		$body.removeClass('is-loading');
-			// 	}, 100);
-			// });
+		// if (skel.canUse('transition'))
+		// 	$body.addClass('is-loading');
+		//
+		// $window.on('load', function() {
+		// 	window.setTimeout(function() {
+		// 		$body.removeClass('is-loading');
+		// 	}, 100);
+		// });
 
 		// Forms.
 
-			// Fix: Placeholder polyfill.
-				$('form').placeholder();
+		// Fix: Placeholder polyfill.
+		$('form').placeholder();
 
-			// Hack: Activate non-input submits.
-				$('form').on('click', '.submit', function(event) {
+		// Hack: Activate non-input submits.
+		$('form').on('click', '.submit', function (event) {
 
-					// Stop propagation, default.
-						event.stopPropagation();
-						event.preventDefault();
+			// Stop propagation, default.
+			event.stopPropagation();
+			event.preventDefault();
 
-					// Submit form.
-						$(this).parents('form').submit();
+			// Submit form.
+			$(this).parents('form').submit();
 
-				});
+		});
 
 		// Prioritize "important" elements on medium.
-			skel.on('+medium -medium', function() {
-				$.prioritize(
-					'.important\\28 medium\\29',
-					skel.breakpoint('medium').active
-				);
-			});
+		skel.on('+medium -medium', function () {
+			$.prioritize(
+				'.important\\28 medium\\29',
+				skel.breakpoint('medium').active
+			);
+		});
 
 		// Sidebar.
-			if ($sidebar.length > 0 ) {
+		if ($sidebar.length > 0) {
 
-				var $sidebar_a = $sidebar.find('a');
+			var $sidebar_a = $sidebar.find('a');
 
-				$sidebar_a
-					.addClass('scrolly')
-					.on('click', function() {
+			$sidebar_a
+				.addClass('scrolly')
+				.on('click', function () {
 
-						var $this = $(this);
+					var $this = $(this);
 
-						// External link? Bail.
-							if ($this.attr('href').charAt(0) != '#')
-								return;
+					// External link? Bail.
+					if ($this.attr('href').charAt(0) != '#')
+						return;
 
-						// Deactivate all links.
-							$sidebar_a.removeClass('active');
+					// Deactivate all links.
+					$sidebar_a.removeClass('active');
 
-						// Activate link *and* lock it (so Scrollex doesn't try to activate other links as we're scrolling to this one's section).
-							$this
-								.addClass('active')
-								.addClass('active-locked');
+					// Activate link *and* lock it (so Scrollex doesn't try to activate other links as we're scrolling to this one's section).
+					$this
+						.addClass('active')
+						.addClass('active-locked');
 
-					})
-					.each(function() {
-
-						var	$this = $(this),
-							id = $this.attr('href'),
-							$section = $(id);
-
-						// No section for this link? Bail.
-							if ($section.length < 1)
-								return;
-
-						// Scrollex.
-							$section.scrollex({
-								mode: 'middle',
-								top: '-20vh',
-								bottom: '-20vh',
-								initialize: function() {
-
-									// Deactivate section.
-										if (skel.canUse('transition'))
-											$section.addClass('inactive');
-
-								},
-								enter: function() {
-
-									// Activate section.
-										$section.removeClass('inactive');
-
-									// No locked links? Deactivate all links and activate this section's one.
-										if ($sidebar_a.filter('.active-locked').length == 0) {
-
-											$sidebar_a.removeClass('active');
-											$this.addClass('active');
-
-										}
-
-									// Otherwise, if this section's link is the one that's locked, unlock it.
-										else if ($this.hasClass('active-locked'))
-											$this.removeClass('active-locked');
-
-								}
-							});
-
-					});
-
-			}
-
-		// Scrolly.
-			$('.scrolly').scrolly({
-				speed: 1000,
-				offset: function() {
-
-					// If <=large, >small, and sidebar is present, use its height as the offset.
-						if (skel.breakpoint('large').active
-						&&	!skel.breakpoint('small').active
-						&&	$sidebar.length > 0)
-							return $sidebar.height();
-
-					return 0;
-
-				}
-			});
-
-		// Spotlights.
-			$('.spotlights > section')
-				.scrollex({
-					mode: 'middle',
-					top: '-10vh',
-					bottom: '-10vh',
-					initialize: function() {
-
-						// Deactivate section.
-							if (skel.canUse('transition'))
-								$(this).addClass('inactive');
-
-					},
-					enter: function() {
-
-						// Activate section.
-							$(this).removeClass('inactive');
-
-					}
 				})
-				.each(function() {
+				;
 
-					var	$this = $(this),
-						$image = $this.find('.image'),
-						$img = $image.find('img'),
-						x;
+			// Defer Scrollex initialization until AngularJS has rendered
+			// sections into ng-view. The sections (#intro, #about, #contact)
+			// live in measure.html, which is loaded asynchronously by
+			// Angular's router, so they don't exist at $(document).ready()
+			// time. See: https://github.com/m-lab/mlab-speedtest/issues/42
+			function initScrollex() {
+				$sidebar_a.each(function () {
 
-					// Assign image.
-						$image.css('background-image', 'url(' + $img.attr('src') + ')');
+					var $this = $(this),
+						id = $this.attr('href'),
+						$section = $(id);
 
-					// Set background position.
-						if (x = $img.data('position'))
-							$image.css('background-position', x);
+					// No section for this link? Bail.
+					if ($section.length < 1)
+						return;
 
-					// Hide <img>.
-						$img.hide();
-
-				});
-
-		// Features.
-			if (skel.canUse('transition'))
-				$('.features')
-					.scrollex({
+					// Scrollex.
+					$section.scrollex({
 						mode: 'middle',
 						top: '-20vh',
 						bottom: '-20vh',
-						initialize: function() {
+						initialize: function () {
 
 							// Deactivate section.
-								$(this).addClass('inactive');
+							if (skel.canUse('transition'))
+								$section.addClass('inactive');
 
 						},
-						enter: function() {
+						enter: function () {
 
 							// Activate section.
-								$(this).removeClass('inactive');
+							$section.removeClass('inactive');
+
+							// No locked links? Deactivate all links and activate this section's one.
+							if ($sidebar_a.filter('.active-locked').length == 0) {
+
+								$sidebar_a.removeClass('active');
+								$this.addClass('active');
+
+							}
+
+							// Otherwise, if this section's link is the one that's locked, unlock it.
+							else if ($this.hasClass('active-locked'))
+								$this.removeClass('active-locked');
 
 						}
 					});
+
+				});
+			}
+
+			// Wait for AngularJS to render sections, then initialize.
+			// Poll until the sections exist (max 5 seconds).
+			var attempts = 0;
+			var maxAttempts = 50;
+			(function waitForSections() {
+				if ($('#intro').length > 0 || $('#about').length > 0) {
+					initScrollex();
+				} else if (attempts < maxAttempts) {
+					attempts++;
+					setTimeout(waitForSections, 100);
+				}
+			})();
+
+		}
+
+		// Scrolly.
+		$('.scrolly').scrolly({
+			speed: 1000,
+			offset: function () {
+
+				// If <=large, >small, and sidebar is present, use its height as the offset.
+				if (skel.breakpoint('large').active
+					&& !skel.breakpoint('small').active
+					&& $sidebar.length > 0)
+					return $sidebar.height();
+
+				return 0;
+
+			}
+		});
+
+		// Spotlights.
+		$('.spotlights > section')
+			.scrollex({
+				mode: 'middle',
+				top: '-10vh',
+				bottom: '-10vh',
+				initialize: function () {
+
+					// Deactivate section.
+					if (skel.canUse('transition'))
+						$(this).addClass('inactive');
+
+				},
+				enter: function () {
+
+					// Activate section.
+					$(this).removeClass('inactive');
+
+				}
+			})
+			.each(function () {
+
+				var $this = $(this),
+					$image = $this.find('.image'),
+					$img = $image.find('img'),
+					x;
+
+				// Assign image.
+				$image.css('background-image', 'url(' + $img.attr('src') + ')');
+
+				// Set background position.
+				if (x = $img.data('position'))
+					$image.css('background-position', x);
+
+				// Hide <img>.
+				$img.hide();
+
+			});
+
+		// Features.
+		if (skel.canUse('transition'))
+			$('.features')
+				.scrollex({
+					mode: 'middle',
+					top: '-20vh',
+					bottom: '-20vh',
+					initialize: function () {
+
+						// Deactivate section.
+						$(this).addClass('inactive');
+
+					},
+					enter: function () {
+
+						// Activate section.
+						$(this).removeClass('inactive');
+
+					}
+				});
 
 	});
 


### PR DESCRIPTION
- Moved the existing Scrollex setup into a separate initScrollex() function for better control over when it runs.
- Added a lightweight check that looks every 100 ms to see if AngularJS has finished loading the sections (#intro, #about, etc.) into         the page.
- As soon as those sections appear, initScrollex() runs and the check stops automatically.
- Nothing about Scrollex itself was changed — only the timing was adjusted so it doesn’t run before the elements exist.

```
var attempts = 0;
var maxAttempts = 50;
(function waitForSections() {
    if ($('#intro').length > 0 || $('#about').length > 0) {
        initScrollex();
    } else if (attempts < maxAttempts) {
        attempts++;
        setTimeout(waitForSections, 100);
    }
})();
```

fixes #42 