### PR TITLE
ci: use unique channel ID per PR for preview deployments

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -17,5 +17,5 @@ jobs:
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_MLAB_SANDBOX }}'
-          channelId: live
+          channelId: 'pr-${{ github.event.number }}'
           projectId: mlab-sandbox


### PR DESCRIPTION
fixes #86 