### PR TITLE
fix: lazily initialize canvas element in ProgressGauge service

### DIFF
--- a/app/services/gaugeService.js
+++ b/app/services/gaugeService.js
@@ -1,54 +1,70 @@
 angular.module('Measure.GaugeService', [])
 
-.factory('ProgressGauge', function() {
-  var aProgress = document.getElementById('activeProgress');
-  var barCTX = aProgress.getContext("2d");
+  .factory('ProgressGauge', function () {
+    // Lazily initialize the canvas element and its context.
+    // The #activeProgress element lives inside Angular's route view, which is
+    // rendered after the service is instantiated, so accessing it at factory
+    // creation time would return null and crash. We defer lookup to first use.
+    var aProgress = null;
+    var barCTX = null;
 
-  function setInactive() {
-    drawProgress(1);
-    aProgress.classList.remove('activeGauge')
-    aProgress.classList.add('inactiveGauge')
-  }
-  function resetProgress() {
-    drawProgress(0);
-    aProgress.classList.remove('inactiveGauge')
-    aProgress.classList.add('activeGauge')
-  }
-  function drawProgress(percentage){
-    var quarterTurn = Math.PI / 2;
-    var endingAngle = ((2*percentage) * Math.PI) - quarterTurn;
-    var startingAngle = 0 - quarterTurn;
+    function getCanvas() {
+      if (!aProgress) {
+        aProgress = document.getElementById('activeProgress');
+        barCTX = aProgress.getContext('2d');
+      }
+    }
 
-    aProgress.width = aProgress.width;
-    barCTX.lineCap = 'square';
+    function setInactive() {
+      getCanvas();
+      drawProgress(1);
+      aProgress.classList.remove('activeGauge')
+      aProgress.classList.add('inactiveGauge')
+    }
+    function resetProgress() {
+      getCanvas();
+      drawProgress(0);
+      aProgress.classList.remove('inactiveGauge')
+      aProgress.classList.add('activeGauge')
+    }
+    function drawProgress(percentage) {
+      getCanvas();
+      var quarterTurn = Math.PI / 2;
+      var endingAngle = ((2 * percentage) * Math.PI) - quarterTurn;
+      var startingAngle = 0 - quarterTurn;
 
-    barCTX.beginPath();
-    barCTX.lineWidth = 20;
-    barCTX.strokeStyle = '#FFFFFF';
-    barCTX.arc(137.5,137.5,111,startingAngle, endingAngle);
-    barCTX.stroke();
-  }
-  function createProgress(){
-    var quarterTurn = Math.PI / 2;
-    var endingAngle = (2 * Math.PI) - quarterTurn;
-    var startingAngle = 0 - quarterTurn;
+      aProgress.width = aProgress.width;
+      barCTX.lineCap = 'square';
 
-    barCTX.beginPath();
-    barCTX.lineCap = 'square';
-    barCTX.lineWidth = 20;
-    barCTX.strokeStyle = '#FFFFFF';
-    barCTX.arc(137.5,137.5,111,startingAngle, endingAngle);
-    barCTX.stroke();
+      barCTX.beginPath();
+      barCTX.lineWidth = 20;
+      barCTX.strokeStyle = '#FFFFFF';
+      barCTX.arc(137.5, 137.5, 111, startingAngle, endingAngle);
+      barCTX.stroke();
+    }
+    function createProgress() {
+      getCanvas();
+      var quarterTurn = Math.PI / 2;
+      var endingAngle = (2 * Math.PI) - quarterTurn;
+      var startingAngle = 0 - quarterTurn;
 
-    setInactive();
-  }
+      barCTX.beginPath();
+      barCTX.lineCap = 'square';
+      barCTX.lineWidth = 20;
+      barCTX.strokeStyle = '#FFFFFF';
+      barCTX.arc(137.5, 137.5, 111, startingAngle, endingAngle);
+      barCTX.stroke();
 
-  return {
-    "element": aProgress,
-    'reset': resetProgress,
-    'progress': drawProgress,
-    'create': createProgress
-  };
+      setInactive();
+    }
+
+    return {
+      'element': function () { getCanvas(); return aProgress; },
+      'reset': resetProgress,
+      'progress': drawProgress,
+      'create': createProgress
+    };
 
 
-});
+  });
+


### PR DESCRIPTION
## Fixes #90 

`gaugeService.js` called `document.getElementById('activeProgress')` at factory creation time — before Angular's router rendered the view containing that element. This caused a `TypeError: Cannot read properties of null (reading 'getContext')` crash.

## Fix

Introduced a `getCanvas()` helper that initializes `aProgress` and `barCTX` on first use. All public functions call `getCanvas()` before accessing the canvas.

```diff
-  var aProgress = document.getElementById('activeProgress');
-  var barCTX = aProgress.getContext("2d");
+  var aProgress = null;
+  var barCTX = null;
+
+  function getCanvas() {
+    if (aProgress.getContext('2d') with a TypeError.) {
+      aProgress = document.getElementById('activeProgress');
+      barCTX = aProgress.getContext('2d');
+    }
+  }
```

By the time any of the public functions (`create`, `reset`, `progress`) are called from the controller, Angular has already rendered the view and `#activeProgress` exists in the DOM.

## Testing

Verified by reviewing call sites in `measure.js` — `ProgressGauge.create()` is called inside the controller after Angular bootstraps, ensuring the element is present.