### PR TITLE
chore: remove unused angular-loader and angular-mocks dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,6 @@
   "dependencies": {
     "@bower_components/angular": "angular/bower-angular#1.5.11",
     "@bower_components/angular-gettext": "rubenv/angular-gettext#*",
-    "@bower_components/angular-loader": "angular/bower-angular-loader#~1.5.0",
-    "@bower_components/angular-mocks": "angular/bower-angular-mocks#~1.5.0",
     "@bower_components/angular-route": "angular/bower-angular-route#~1.5.0",
     "@bower_components/html5-boilerplate": "h5bp/html5-boilerplate#^5.3.0",
     "@bower_components/jquery": "jquery/jquery-dist#3.0.0",


### PR DESCRIPTION
## Summary

Removes two unused dependencies from `package.json` that have no references anywhere in the project.

Closes #40

## What was removed

| Dependency | Reason unused |
|---|---|
| `@bower_components/angular-loader` | Not referenced in any `<script>` tag in `index.html` or any language variant |
| `@bower_components/angular-mocks` | Intended for Karma/Jasmine unit tests, but no test files exist in this repository |

## Verification

Searched the entire `app/` directory and `gulpfile.js` for any reference to either package — no matches found:

```sh
$ grep -r "angular-loader" app/
(no output)

$ grep -r "angular-mocks" app/
(no output)
```

All other dependencies remain — confirmed still in active use via `<script>` tags (e.g. `angular-route`, `angular-gettext`, `jquery`).