### PR TITLE
ci: add concurrency groups to prevent deployment race conditions

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -6,6 +6,10 @@ name: Deploy to Firebase Hosting on merge
   push:
     branches:
       - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
   checks: write

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -3,6 +3,10 @@
 
 name: Deploy to Firebase Hosting on PR
 'on': pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 permissions:
   contents: read
   checks: write


### PR DESCRIPTION
## Fixes #93 

Both workflows lack a `concurrency` group. This causes two issues:

**Merge workflow:** If two commits are pushed to `main` in quick succession, both builds run in parallel. If the older build finishes last, it deploys stale code to `mlab-oti`, overwriting the newer deployment.

**PR workflow:** Rapid fix-up commits to a PR branch spin up a new runner for every push, wasting CI minutes on builds that are no longer needed.

## Fix

Added a `concurrency` block to both workflows.

```yaml
# PR workflow — uses head_ref (branch name) so each PR has its own group
concurrency:
  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
  cancel-in-progress: true

# Merge workflow — uses ref (main branch) to serialize production deploys
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

The `|| github.run_id` fallback on the PR workflow ensures non-PR triggers always get a unique group and are never incorrectly cancelled.

## Safety

These are standard build-and-deploy workflows for a static frontend — no migrations, no cleanup tasks. Cancelling a stale run is always safe here.