### PR TITLE
fixes the issue #36

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "description": "M-Lab interface to NDTjs",
   "homepage": "https://github.com/mlab-speedtest",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "devDependencies": {
     "bower": "^1.8.8",
     "gulp": "^4.0.2",


### PR DESCRIPTION
## Summary

The repository's `LICENSE` file contains the Apache License 2.0, but `package.json` listed the project license as MIT.

This PR updates the `license` field in `package.json` to `Apache-2.0` so that the metadata matches the actual license used in the repository.
#36 
## Changes made

- Updated `package.json`:
  - `"license": "MIT"` → `"license": "Apache-2.0"`

## Why this change

Keeping license metadata consistent helps avoid confusion for contributors and downstream users/tools that rely on package metadata.
