### PR TITLE
fix: upgrade http:// links to https:// across all pages

### DIFF
--- a/app/az/index.html
+++ b/app/az/index.html
@@ -37,9 +37,9 @@
 		<footer id="footer" class="wrapper style1-alt">
 			<div class="inner">
 				<ul class="menu">
-					<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
-					<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
-					<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+					<li><a href="https://www.measurementlab.net/">Measurement Lab</a></li>
+					<li>Template: <a href="https://html5up.net">HTML5 UP</a></li>
+					<li><a href="https://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
 				</ul>
 			</div>
 		</footer>

--- a/app/de/index.html
+++ b/app/de/index.html
@@ -37,9 +37,9 @@
 		<footer id="footer" class="wrapper style1-alt">
 			<div class="inner">
 				<ul class="menu">
-					<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
-					<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
-					<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+					<li><a href="https://www.measurementlab.net/">Measurement Lab</a></li>
+					<li>Template: <a href="https://html5up.net">HTML5 UP</a></li>
+					<li><a href="https://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
 				</ul>
 			</div>
 		</footer>

--- a/app/el/index.html
+++ b/app/el/index.html
@@ -37,9 +37,9 @@
 		<footer id="footer" class="wrapper style1-alt">
 			<div class="inner">
 				<ul class="menu">
-					<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
-					<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
-					<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+					<li><a href="https://www.measurementlab.net/">Measurement Lab</a></li>
+					<li>Template: <a href="https://html5up.net">HTML5 UP</a></li>
+					<li><a href="https://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
 				</ul>
 			</div>
 		</footer>

--- a/app/es/index.html
+++ b/app/es/index.html
@@ -37,9 +37,9 @@
 		<footer id="footer" class="wrapper style1-alt">
 			<div class="inner">
 				<ul class="menu">
-					<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
-					<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
-					<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+					<li><a href="https://www.measurementlab.net/">Measurement Lab</a></li>
+					<li>Template: <a href="https://html5up.net">HTML5 UP</a></li>
+					<li><a href="https://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
 				</ul>
 			</div>
 		</footer>

--- a/app/fa/index.html
+++ b/app/fa/index.html
@@ -37,9 +37,9 @@
 		<footer id="footer" class="wrapper style1-alt">
 			<div class="inner">
 				<ul class="menu">
-					<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
-					<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
-					<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+					<li><a href="https://www.measurementlab.net/">Measurement Lab</a></li>
+					<li>Template: <a href="https://html5up.net">HTML5 UP</a></li>
+					<li><a href="https://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
 				</ul>
 			</div>
 		</footer>

--- a/app/fr/index.html
+++ b/app/fr/index.html
@@ -37,9 +37,9 @@
 		<footer id="footer" class="wrapper style1-alt">
 			<div class="inner">
 				<ul class="menu">
-					<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
-					<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
-					<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+					<li><a href="https://www.measurementlab.net/">Measurement Lab</a></li>
+					<li>Template: <a href="https://html5up.net">HTML5 UP</a></li>
+					<li><a href="https://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
 				</ul>
 			</div>
 		</footer>

--- a/app/hi/index.html
+++ b/app/hi/index.html
@@ -37,9 +37,9 @@
 		<footer id="footer" class="wrapper style1-alt">
 			<div class="inner">
 				<ul class="menu">
-					<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
-					<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
-					<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+					<li><a href="https://www.measurementlab.net/">Measurement Lab</a></li>
+					<li>Template: <a href="https://html5up.net">HTML5 UP</a></li>
+					<li><a href="https://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
 				</ul>
 			</div>
 		</footer>

--- a/app/id/index.html
+++ b/app/id/index.html
@@ -37,9 +37,9 @@
 		<footer id="footer" class="wrapper style1-alt">
 			<div class="inner">
 				<ul class="menu">
-					<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
-					<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
-					<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+					<li><a href="https://www.measurementlab.net/">Measurement Lab</a></li>
+					<li>Template: <a href="https://html5up.net">HTML5 UP</a></li>
+					<li><a href="https://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
 				</ul>
 			</div>
 		</footer>

--- a/app/index.html
+++ b/app/index.html
@@ -34,9 +34,9 @@
 		<footer id="footer" class="wrapper style1-alt">
 			<div class="inner">
 				<ul class="menu">
-					<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
-					<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
-					<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+					<li><a href="https://www.measurementlab.net/">Measurement Lab</a></li>
+					<li>Template: <a href="https://html5up.net">HTML5 UP</a></li>
+					<li><a href="https://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
 				</ul>
 			</div>
 		</footer>

--- a/app/measure/measure.html
+++ b/app/measure/measure.html
@@ -10,7 +10,7 @@
       <p>
         <input type="checkbox" id="demo-human" name="demo-human" ng-model="privacyConsent">
         <label for="demo-human" translate style="font-size: smaller;">I agree to the <a
-            href="http://www.measurementlab.net/privacy/">data policy</a>, which includes retention and publication of
+            href="https://www.measurementlab.net/privacy/">data policy</a>, which includes retention and publication of
           IP addresses.</label>
       </p>
       <p>
@@ -37,7 +37,7 @@
         results may take a little longer to appear than usual. Thank you for your help.
       </small><br /><br />
       <small translate>For more on M-Lab's data collection and measurement, including the disclosure of IP addresses,
-        see our <a href="http://www.measurementlab.net/privacy/">Privacy Policy</a>.</small>
+        see our <a href="https://www.measurementlab.net/privacy/">Privacy Policy</a>.</small>
     </section>
     <section id="measurementSpace">
       <div ng-show="!measurementComplete">
@@ -131,7 +131,7 @@
       </section>
     </div>
     <ul class="actions">
-      <li><a href="http://measurementlab.net" class="button" translate>Learn more</a></li>
+      <li><a href="https://www.measurementlab.net" class="button" translate>Learn more</a></li>
     </ul>
   </div>
 </section>

--- a/app/nl/index.html
+++ b/app/nl/index.html
@@ -37,9 +37,9 @@
 		<footer id="footer" class="wrapper style1-alt">
 			<div class="inner">
 				<ul class="menu">
-					<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
-					<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
-					<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+					<li><a href="https://www.measurementlab.net/">Measurement Lab</a></li>
+					<li>Template: <a href="https://html5up.net">HTML5 UP</a></li>
+					<li><a href="https://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
 				</ul>
 			</div>
 		</footer>

--- a/app/ru/index.html
+++ b/app/ru/index.html
@@ -37,9 +37,9 @@
 		<footer id="footer" class="wrapper style1-alt">
 			<div class="inner">
 				<ul class="menu">
-					<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
-					<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
-					<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+					<li><a href="https://www.measurementlab.net/">Measurement Lab</a></li>
+					<li>Template: <a href="https://html5up.net">HTML5 UP</a></li>
+					<li><a href="https://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
 				</ul>
 			</div>
 		</footer>

--- a/app/zh/index.html
+++ b/app/zh/index.html
@@ -37,9 +37,9 @@
 		<footer id="footer" class="wrapper style1-alt">
 			<div class="inner">
 				<ul class="menu">
-					<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
-					<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
-					<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+					<li><a href="https://www.measurementlab.net/">Measurement Lab</a></li>
+					<li>Template: <a href="https://html5up.net">HTML5 UP</a></li>
+					<li><a href="https://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
 				</ul>
 			</div>
 		</footer>


### PR DESCRIPTION
## Summary

All external links across the site (footer, privacy policy, and the "Learn more" button) were using `http://` URLs for `measurementlab.net` and `html5up.net`. Both sites fully support HTTPS.

This PR upgrades those links to `https://` for better security and consistency — especially relevant for a network measurement tool.

## Changes made

- Updated `app/index.html` — footer links
- Updated `app/measure/measure.html` — privacy policy links and "Learn more" button
- Updated all 11 language-specific `index.html` files (`az`, `de`, `el`, `es`, `fa`, `fr`, `hi`, `id`, `nl`, `ru`, `zh`) — footer links

- `http://www.measurementlab.net/` → `https://www.measurementlab.net/`
- `http://measurementlab.net` → `https://www.measurementlab.net/`
- `http://html5up.net` → `https://html5up.net`

## Why this change

Using plain HTTP links on a site dedicated to network measurement sends the wrong signal. Both target sites already support HTTPS and redirect HTTP → HTTPS, so this change avoids unnecessary redirects and removes potential mixed-content concerns.
