### PR TITLE
fix: add missing MSAK and PT script tags to language pages

### DIFF
--- a/app/az/index.html
+++ b/app/az/index.html
@@ -62,6 +62,8 @@
 	  <script type="text/javascript" src="/libraries/re-tree.min.js"></script>
 	  <script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
 	  <script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+	  <script type="text/javascript" src="/libraries/msak.min.js"></script>
+	  <script type="text/javascript" src="/libraries/pt.min.js"></script>
 
       <script src="/assets/translations/az.js"></script>
 	  <script src="/measure/measure.js"></script>

--- a/app/de/index.html
+++ b/app/de/index.html
@@ -62,6 +62,8 @@
 	  <script type="text/javascript" src="/libraries/re-tree.min.js"></script>
 	  <script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
 	  <script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+	  <script type="text/javascript" src="/libraries/msak.min.js"></script>
+	  <script type="text/javascript" src="/libraries/pt.min.js"></script>
 
       <script src="/assets/translations/de_DE.js"></script>
 	  <script src="/measure/measure.js"></script>

--- a/app/el/index.html
+++ b/app/el/index.html
@@ -62,6 +62,8 @@
 	  <script type="text/javascript" src="/libraries/re-tree.min.js"></script>
 	  <script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
 	  <script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+	  <script type="text/javascript" src="/libraries/msak.min.js"></script>
+	  <script type="text/javascript" src="/libraries/pt.min.js"></script>
 
       <script src="/assets/translations/el.js"></script>
 	  <script src="/measure/measure.js"></script>

--- a/app/es/index.html
+++ b/app/es/index.html
@@ -62,6 +62,8 @@
 	  <script type="text/javascript" src="/libraries/re-tree.min.js"></script>
 	  <script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
 	  <script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+	  <script type="text/javascript" src="/libraries/msak.min.js"></script>
+	  <script type="text/javascript" src="/libraries/pt.min.js"></script>
 
       <script src="/assets/translations/es.js"></script>
 	  <script src="/measure/measure.js"></script>

--- a/app/fa/index.html
+++ b/app/fa/index.html
@@ -62,6 +62,8 @@
 	  <script type="text/javascript" src="/libraries/re-tree.min.js"></script>
 	  <script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
 	  <script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+	  <script type="text/javascript" src="/libraries/msak.min.js"></script>
+	  <script type="text/javascript" src="/libraries/pt.min.js"></script>
 
       <script src="/assets/translations/fa.js"></script>
 	  <script src="/measure/measure.js"></script>

--- a/app/fr/index.html
+++ b/app/fr/index.html
@@ -62,6 +62,8 @@
 	  <script type="text/javascript" src="/libraries/re-tree.min.js"></script>
 	  <script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
 	  <script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+	  <script type="text/javascript" src="/libraries/msak.min.js"></script>
+	  <script type="text/javascript" src="/libraries/pt.min.js"></script>
 
       <script src="/assets/translations/fr.js"></script>
 	  <script src="/measure/measure.js"></script>

--- a/app/hi/index.html
+++ b/app/hi/index.html
@@ -62,6 +62,8 @@
 	  <script type="text/javascript" src="/libraries/re-tree.min.js"></script>
 	  <script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
 	  <script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+	  <script type="text/javascript" src="/libraries/msak.min.js"></script>
+	  <script type="text/javascript" src="/libraries/pt.min.js"></script>
 
       <script src="/assets/translations/hi.js"></script>
 	  <script src="/measure/measure.js"></script>

--- a/app/id/index.html
+++ b/app/id/index.html
@@ -62,6 +62,8 @@
 	  <script type="text/javascript" src="/libraries/re-tree.min.js"></script>
 	  <script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
 	  <script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+	  <script type="text/javascript" src="/libraries/msak.min.js"></script>
+	  <script type="text/javascript" src="/libraries/pt.min.js"></script>
 
       <script src="/assets/translations/id.js"></script>
 	  <script src="/measure/measure.js"></script>

--- a/app/nl/index.html
+++ b/app/nl/index.html
@@ -62,6 +62,8 @@
 	  <script type="text/javascript" src="/libraries/re-tree.min.js"></script>
 	  <script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
 	  <script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+	  <script type="text/javascript" src="/libraries/msak.min.js"></script>
+	  <script type="text/javascript" src="/libraries/pt.min.js"></script>
 
       <script src="/assets/translations/nl.js"></script>
 	  <script src="/measure/measure.js"></script>

--- a/app/ru/index.html
+++ b/app/ru/index.html
@@ -62,6 +62,8 @@
 	  <script type="text/javascript" src="/libraries/re-tree.min.js"></script>
 	  <script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
 	  <script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+	  <script type="text/javascript" src="/libraries/msak.min.js"></script>
+	  <script type="text/javascript" src="/libraries/pt.min.js"></script>
 
       <script src="/assets/translations/ru.js"></script>
 	  <script src="/measure/measure.js"></script>

--- a/app/zh/index.html
+++ b/app/zh/index.html
@@ -62,6 +62,8 @@
 	  <script type="text/javascript" src="/libraries/re-tree.min.js"></script>
 	  <script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
 	  <script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+	  <script type="text/javascript" src="/libraries/msak.min.js"></script>
+	  <script type="text/javascript" src="/libraries/pt.min.js"></script>
 
       <script src="/assets/translations/zh.js"></script>
 	  <script src="/measure/measure.js"></script>


### PR DESCRIPTION
## Summary
The main index.html includes msak.min.js and pt.min.js, but none of the 11 language-specific pages included these scripts. This means the MSAK speed test silently fails for anyone using a non-English version of the site.

## Changes made
Added the missing <script> tags for msak.min.js and pt.min.js to all 11 language-specific index.html files (az, de, el, es, fa, fr, hi, id, nl, ru, zh).

## Why this change
Without these scripts, the msak object is undefined when measure.js tries to create an MSAK client, so the MSAK portion of the speed test fails silently for all non-English users.