### PR TITLE
ci: add timeout-minutes to prevent hung builds running for 6 hours

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - run: npm install -g yarn && yarn install --frozen-lockfile && yarn build

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -10,6 +10,7 @@ jobs:
   build_and_preview:
     if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - run: npm install -g yarn && yarn install --frozen-lockfile && yarn build


### PR DESCRIPTION

## Fixes #100 

Both workflow jobs have no `timeout-minutes` set. If `yarn install` or the Firebase deploy step hangs (network failure, broken registry), the workflow runs until GitHub's default limit of **6 hours**, silently burning CI minutes and blocking the pipeline.

## Fix

Added `timeout-minutes: 15` to both job definitions.

```diff
   build_and_deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
```

15 minutes is enough for a complete build and deploy under normal conditions, while failing fast if something hangs.