### PR TITLE
fix: disable MSAK client debug mode in production

### DIFF
--- a/app/measure/measure.js
+++ b/app/measure/measure.js
@@ -225,7 +225,7 @@ angular.module('Measure.Measure', ['ngRoute'])
       client.cc = "cubic";
       client.duration = 10000; // 10s
       client.streams = 1;
-      client.debug = true;
+      client.debug = false;
 
       await client.start();
     }


### PR DESCRIPTION
## Problem

`client.debug` was set to `true` in `runMSAK()`, enabling verbose internal logging to the browser console for every user running a speed test. Debug output should never ship to production.

## Fix

```diff
-      client.debug = true;
+      client.debug = false;
```