### PR TITLE
ci: add pull-requests: write permission for Firebase preview comments

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -6,6 +6,7 @@ name: Deploy to Firebase Hosting on PR
 permissions:
   contents: read
   checks: write
+  pull-requests: write
 jobs:
   build_and_preview:
     if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'


### PR DESCRIPTION
## Problem

The PR workflow is missing the `pull-requests: write` permission. The `FirebaseExtended/action-hosting-deploy` action requires this permission to post the preview deployment URL as a comment on the PR.

Without it, the preview URL is never posted — contributors have no clickable link to their deployment.

## Fix

```diff
 permissions:
   contents: read
   checks: write
+  pull-requests: write
```