### PR TITLE
docs: add SECURITY.md with vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please **do not** open a public GitHub issue. Instead, report it responsibly by emailing:
+
+**support@measurementlab.net**
+
+Please include:
+- A description of the vulnerability and its potential impact
+- Steps to reproduce the issue
+- Any relevant URLs or screenshots
+
+M-Lab will acknowledge your report within **5 business days** and aim to release a fix within **90 days**, depending on severity.
+
+## Scope
+
+This repository contains the front-end source code for [speed.measurementlab.net](https://speed.measurementlab.net). The site is a static web application — it does not handle user authentication, store personal data server-side, or manage sensitive credentials directly.
+
+Speed test measurements are conducted client-side and transmitted to M-Lab's infrastructure. For security concerns related to M-Lab's broader infrastructure or data handling, see [measurementlab.net/privacy](https://www.measurementlab.net/privacy/).
+
+## Supported Versions
+
+Only the latest version deployed to [speed.measurementlab.net](https://speed.measurementlab.net) (tracking the `main` branch) is actively maintained.


### PR DESCRIPTION
## Summary

Adds `SECURITY.md` — GitHub recommends this for all public repositories and displays a warning when it's missing.

Covers:
- How to privately report vulnerabilities (email to support@measurementlab.net)
- Project scope (static frontend, no auth or server-side data storage)
- Supported versions (main branch only)