### PR TITLE
fix: reset testRunning flag and re-enable button on test failure

### DIFF
--- a/app/measure/measure.js
+++ b/app/measure/measure.js
@@ -48,21 +48,33 @@ angular.module('Measure.Measure', ['ngRoute'])
       const sessionID = uuidv4();
 
       // Randomly choose which test to start first.
-      if (Math.random() < 0.5) {
-        await runNdt7(sessionID)
-        await runMSAK(sessionID);
-      } else {
-        await runMSAK(sessionID);
-        await runNdt7(sessionID);
-      }
+      try {
+        if (Math.random() < 0.5) {
+          await runNdt7(sessionID);
+          await runMSAK(sessionID);
+        } else {
+          await runMSAK(sessionID);
+          await runNdt7(sessionID);
+        }
 
-      $scope.$apply(function () {
-        $scope.currentPhase = gettextCatalog.getString('Complete');
-        $scope.currentSpeed = '';
-        $scope.measurementComplete = true;
-        $scope.startButtonClass = '';
-      });
-      testRunning = false;
+        $scope.$apply(function () {
+          $scope.currentPhase = gettextCatalog.getString('Complete');
+          $scope.currentSpeed = '';
+          $scope.measurementComplete = true;
+          $scope.startButtonClass = '';
+        });
+      } catch (err) {
+        // If a test fails (e.g. network error), re-enable the button so the
+        // user can retry without having to refresh the page.
+        $scope.$apply(function () {
+          $scope.currentPhase = '';
+          $scope.currentSpeed = '';
+          $scope.startButtonClass = '';
+        });
+      } finally {
+        // Always reset the flag, whether the test succeeded or failed.
+        testRunning = false;
+      }
     }
 
     // Determine the M-Lab project based on a placeholder that is substituted


### PR DESCRIPTION
## Fixes #109 
## Problem

If `runNdt7` or `runMSAK` threw an error (e.g. network failure, server unreachable), the `testRunning` flag was never reset and `startButtonClass` remained `'disabled'`. This permanently blocked the Start button — the user had no way to retry without refreshing the entire page.

## Fix

Wrapped the test runner calls in `try/catch/finally`:

- **Success path** — unchanged, shows 'Complete' state as before
- **Catch** — re-enables the button via `$scope.$apply` so the user can retry immediately
- **Finally** — always resets `testRunning = false`, whether the test succeeded or failed

```diff
-      if (Math.random() < 0.5) {
-        await runNdt7(sessionID)
-        await runMSAK(sessionID);
-      } else { ... }
-      $scope.$apply(function () { ... });
-      testRunning = false;
+      try {
+        if (Math.random() < 0.5) {
+          await runNdt7(sessionID);
+          await runMSAK(sessionID);
+        } else { ... }
+        $scope.$apply(function () { ... complete state ... });
+      } catch (err) {
+        $scope.$apply(function () { ... reset UI ... });
+      } finally {
+        testRunning = false;
+      }
```