### PR TITLE
fix: add lang attribute to all HTML pages for accessibility

### DIFF
--- a/app/az/index.html
+++ b/app/az/index.html
@@ -4,7 +4,7 @@
 	html5up.net | @ajlkn
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
-<html ng-app="Measure">
+<html ng-app="Measure" lang="az">
 	<head>
 		<title>Speed Test by Measurement Lab</title>
 		<meta charset="utf-8" />

--- a/app/de/index.html
+++ b/app/de/index.html
@@ -4,7 +4,7 @@
 	html5up.net | @ajlkn
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
-<html ng-app="Measure">
+<html ng-app="Measure" lang="de">
 	<head>
 		<title>Speed Test by Measurement Lab</title>
 		<meta charset="utf-8" />

--- a/app/el/index.html
+++ b/app/el/index.html
@@ -4,7 +4,7 @@
 	html5up.net | @ajlkn
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
-<html ng-app="Measure">
+<html ng-app="Measure" lang="el">
 	<head>
 		<title>Speed Test by Measurement Lab</title>
 		<meta charset="utf-8" />

--- a/app/es/index.html
+++ b/app/es/index.html
@@ -4,7 +4,7 @@
 	html5up.net | @ajlkn
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
-<html ng-app="Measure">
+<html ng-app="Measure" lang="es">
 	<head>
 		<title>Speed Test by Measurement Lab</title>
 		<meta charset="utf-8" />

--- a/app/fa/index.html
+++ b/app/fa/index.html
@@ -4,7 +4,7 @@
 	html5up.net | @ajlkn
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
-<html ng-app="Measure">
+<html ng-app="Measure" lang="fa" dir="rtl">
 	<head>
 		<title>Speed Test by Measurement Lab</title>
 		<meta charset="utf-8" />

--- a/app/fr/index.html
+++ b/app/fr/index.html
@@ -4,7 +4,7 @@
 	html5up.net | @ajlkn
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
-<html ng-app="Measure">
+<html ng-app="Measure" lang="fr">
 	<head>
 		<title>Speed Test by Measurement Lab</title>
 		<meta charset="utf-8" />

--- a/app/hi/index.html
+++ b/app/hi/index.html
@@ -4,7 +4,7 @@
 	html5up.net | @ajlkn
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
-<html ng-app="Measure">
+<html ng-app="Measure" lang="hi">
 	<head>
 		<title>Speed Test by Measurement Lab</title>
 		<meta charset="utf-8" />

--- a/app/id/index.html
+++ b/app/id/index.html
@@ -4,7 +4,7 @@
 	html5up.net | @ajlkn
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
-<html ng-app="Measure">
+<html ng-app="Measure" lang="id">
 	<head>
 		<title>Speed Test by Measurement Lab</title>
 		<meta charset="utf-8" />

--- a/app/index.html
+++ b/app/index.html
@@ -4,7 +4,7 @@
 	html5up.net | @ajlkn
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
-<html ng-app="Measure">
+<html ng-app="Measure" lang="en">
 	<head>
 		<title>Speed Test by Measurement Lab</title>
 		<meta charset="utf-8" />

--- a/app/nl/index.html
+++ b/app/nl/index.html
@@ -4,7 +4,7 @@
 	html5up.net | @ajlkn
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
-<html ng-app="Measure">
+<html ng-app="Measure" lang="nl">
 	<head>
 		<title>Speed Test by Measurement Lab</title>
 		<meta charset="utf-8" />

--- a/app/ru/index.html
+++ b/app/ru/index.html
@@ -4,7 +4,7 @@
 	html5up.net | @ajlkn
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
-<html ng-app="Measure">
+<html ng-app="Measure" lang="ru">
 	<head>
 		<title>Speed Test by Measurement Lab</title>
 		<meta charset="utf-8" />

--- a/app/zh/index.html
+++ b/app/zh/index.html
@@ -4,7 +4,7 @@
 	html5up.net | @ajlkn
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
-<html ng-app="Measure">
+<html ng-app="Measure" lang="zh">
 	<head>
 		<title>Speed Test by Measurement Lab</title>
 		<meta charset="utf-8" />


### PR DESCRIPTION
## Fixes #111 

None of the HTML pages declare a `lang` attribute on the `<html>` element, violating [WCAG 2.1 criterion 3.1.1](https://www.w3.org/WAI/WCAG21/Understanding/language-of-page) (Language of Page).

Without it:
- Screen readers cannot select the correct language voice profile
- Browsers cannot apply correct hyphenation and text rendering rules
- Search engines may not index pages under the correct language

The Persian (`fa`) page is the most impactful case — Persian is right-to-left, so the missing `dir="rtl"` attribute means the browser does not apply RTL layout.

## Fix

Added the appropriate `lang` attribute to all 12 HTML files:

| File | Change |
|------|--------|
| `app/index.html` | `lang="en"` |
| `app/az/index.html` | `lang="az"` |
| `app/de/index.html` | `lang="de"` |
| `app/el/index.html` | `lang="el"` |
| `app/es/index.html` | `lang="es"` |
| `app/fa/index.html` | `lang="fa" dir="rtl"` |
| `app/fr/index.html` | `lang="fr"` |
| `app/hi/index.html` | `lang="hi"` |
| `app/id/index.html` | `lang="id"` |
| `app/nl/index.html` | `lang="nl"` |
| `app/ru/index.html` | `lang="ru"` |
| `app/zh/index.html` | `lang="zh"` |