### PR TITLE
ci: harden workflow configuration

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -11,13 +11,13 @@ permissions:
   checks: write
 jobs:
   build_and_deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - run: npm install -g yarn && yarn install --frozen-lockfile && yarn build
       - name: Substitute M-Lab project placeholder
         run: sed -i 's/MLAB_PROJECT_PLACEHOLDER/mlab-oti/g' app/measure/measure.js
-      - uses: FirebaseExtended/action-hosting-deploy@v0
+      - uses: FirebaseExtended/action-hosting-deploy@e2eda2e106cfa35cdbcf4ac9ddaf6c4756df2c8c # v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_MLAB_OTI }}'

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -2,18 +2,20 @@
 # https://github.com/firebase/firebase-tools
 
 name: Deploy to Firebase Hosting on PR
-'on': pull_request
+'on':
+  pull_request:
+    types: [opened, synchronize, reopened]
 permissions:
   contents: read
   checks: write
 jobs:
   build_and_preview:
     if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - run: npm install -g yarn && yarn install --frozen-lockfile && yarn build
-      - uses: FirebaseExtended/action-hosting-deploy@v0
+      - uses: FirebaseExtended/action-hosting-deploy@e2eda2e106cfa35cdbcf4ac9ddaf6c4756df2c8c # v0
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_MLAB_SANDBOX }}'


### PR DESCRIPTION
## fixes #113 
Three changes to make the CI pipeline more robust:

**1. Scope PR trigger types**
The PR workflow triggered on all `pull_request` activity types, including labeling, editing descriptions, and locking — none of which change code. Scoped to `[opened, synchronize, reopened]` to avoid unnecessary builds.

**2. Pin runner to `ubuntu-22.04`**
`ubuntu-latest` can silently change OS versions (e.g. 22.04 → 24.04), potentially breaking builds due to different system packages or default tool versions.

**3. SHA-pin `FirebaseExtended/action-hosting-deploy`**
Using a floating tag (`@v0`) means any future commit pushed to that tag runs in the workflow automatically. Pinning to the full commit SHA (`e2eda2e`) prevents supply chain attacks while keeping a version comment for reference.

```diff
-'on': pull_request
+'on':
+  pull_request:
+    types: [opened, synchronize, reopened]

-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04

-      - uses: FirebaseExtended/action-hosting-deploy@v0
+      - uses: FirebaseExtended/action-hosting-deploy@e2eda2e106cfa35cdbcf4ac9ddaf6c4756df2c8c # v0
```