### PR TITLE
ci: add Dependabot config for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Fixes #116 
The repository has no way to track outdated GitHub Actions. When actions like `actions/checkout` or `FirebaseExtended/action-hosting-deploy` release security patches, nobody is notified.

Adds a Dependabot configuration that checks for GitHub Actions updates weekly and opens PRs automatically. This is free, built into GitHub, and requires no additional setup.