### PR TITLE
fix: correct typos and grammar in README and UI strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ Translations for this site are managed in the [Open Technology Fund's Localizati
 * Download a completed language translation file
   * Visit the Transifex site and locate a completed language
   * Click **Interface Language Strings** and then **Download for use** to download the completed language `.po` file
-  * Save it in the folder: `/translations/source/` using the file name pattern: **<two letter langugage code>.po**
+  * Save it in the folder: `/translations/source/` using the file name pattern: **<two letter language code>.po**
 * Create new language template & update language string references
   * Create a copy of an existing translation folder and index.html file, and make some edits to support the new language
     * Copy the folder and index file: `cp -r app/nl app/es`
     * Edit the index file to change the language it references. In `app/es/index.html`: 
       * change: `const INTERFACE_LANGUAGE = 'nl';` to `const INTERFACE_LANGUAGE = 'es';`
-      * change: `<script src="/assets/translations/it.js"></script>`
+      * change: `<script src="/assets/translations/nl.js"></script>`
     * to: `<script src="/assets/translations/es.js"></script>`
   * Regenerate the supported language strings: 
     * `gulp inject`

--- a/app/measure/measure.html
+++ b/app/measure/measure.html
@@ -120,13 +120,13 @@
       <section>
         <span class="icon major fa-globe"></span>
         <h3 translate>Global</h3>
-        <p translate>Distributed infrastructure and large user base provides an open, verifiable measurement platform
+        <p translate>Distributed infrastructure and large user base provide an open, verifiable measurement platform
           for global network performance.</p>
       </section>
       <section>
         <span class="icon major fa-institution"></span>
         <h3 translate>Trusted</h3>
-        <p translate>Used by public organization, academic researchers, regulators and companies around the world to
+        <p translate>Used by public organizations, academic researchers, regulators and companies around the world to
           understand the health of the Internet.</p>
       </section>
     </div>

--- a/translations/languages/az.po
+++ b/translations/languages/az.po
@@ -46,7 +46,7 @@ msgstr "Müzakirə və Bildiriş Qrupu"
 
 #: measure.html:97
 msgid ""
-"Distributed infrastructure and large user base provides an open, verifiable "
+"Distributed infrastructure and large user base provide an open, verifiable "
 "measurement platform for global network performance."
 msgstr ""
 "Paylanmış infrastruktur və geniş istifadəçi bazası qlobal şəbəkə işi üçün "
@@ -207,7 +207,7 @@ msgstr "Yüklə"
 
 #: measure.html:102
 msgid ""
-"Used by public organization, academic researchers, regulators and companies "
+"Used by public organizations, academic researchers, regulators and companies "
 "around the world to understand the health of the Internet."
 msgstr ""
 "İnternetin durumunu anlamaq üçün ictimai təşkilat, akademik tədqiqatçılar, "

--- a/translations/languages/de_DE.po
+++ b/translations/languages/de_DE.po
@@ -47,7 +47,7 @@ msgstr "Diskussions- und Benachrichtungsgruppe"
 
 #: measure.html:97
 msgid ""
-"Distributed infrastructure and large user base provides an open, verifiable "
+"Distributed infrastructure and large user base provide an open, verifiable "
 "measurement platform for global network performance."
 msgstr ""
 "Verteilte Infrastruktur und eine grosse Nutzerbasis stellen eine offene, "
@@ -207,7 +207,7 @@ msgstr "Hochladen"
 
 #: measure.html:102
 msgid ""
-"Used by public organization, academic researchers, regulators and companies "
+"Used by public organizations, academic researchers, regulators and companies "
 "around the world to understand the health of the Internet."
 msgstr ""
 "Verwendet durch öffentliche Organisationen, Akademische Forscher, Behörden "

--- a/translations/languages/el.po
+++ b/translations/languages/el.po
@@ -47,7 +47,7 @@ msgstr "Ομάδα Συζήτηση και Κοινοποίησης"
 
 #: measure.html:97
 msgid ""
-"Distributed infrastructure and large user base provides an open, verifiable "
+"Distributed infrastructure and large user base provide an open, verifiable "
 "measurement platform for global network performance."
 msgstr ""
 "Η κατανεμημένη υποδομή και μεγάλη βάση χρηστών παρέχει μια ανοιχτοί, "
@@ -208,7 +208,7 @@ msgstr "Μεταφόρτωση"
 
 #: measure.html:102
 msgid ""
-"Used by public organization, academic researchers, regulators and companies "
+"Used by public organizations, academic researchers, regulators and companies "
 "around the world to understand the health of the Internet."
 msgstr ""
 "Χρησιμοποιείται από δημόσιους οργανισμους, ακαδημαϊκούς ερευνητές, οι "

--- a/translations/languages/es.po
+++ b/translations/languages/es.po
@@ -46,7 +46,7 @@ msgstr "Grupo de debate y notificación"
 
 #: measure.html:97
 msgid ""
-"Distributed infrastructure and large user base provides an open, verifiable "
+"Distributed infrastructure and large user base provide an open, verifiable "
 "measurement platform for global network performance."
 msgstr ""
 "La infraestructura distribuida y la gran base de usuarios proporcionan una "
@@ -207,7 +207,7 @@ msgstr "Subida"
 
 #: measure.html:102
 msgid ""
-"Used by public organization, academic researchers, regulators and companies "
+"Used by public organizations, academic researchers, regulators and companies "
 "around the world to understand the health of the Internet."
 msgstr ""
 "Utilizado por organizaciones públicas, investigadores académicos, "

--- a/translations/languages/fa.po
+++ b/translations/languages/fa.po
@@ -45,7 +45,7 @@ msgstr "گروه بحث و اطلاع‌رسانی"
 
 #: measure.html:97
 msgid ""
-"Distributed infrastructure and large user base provides an open, verifiable "
+"Distributed infrastructure and large user base provide an open, verifiable "
 "measurement platform for global network performance."
 msgstr ""
 "زیرساخت توزیع شده و پایگاه وسیع کاربری یک پلتفرم سنجش آزاد و قابل تصدیق را "
@@ -203,7 +203,7 @@ msgstr "بارگذاری"
 
 #: measure.html:102
 msgid ""
-"Used by public organization, academic researchers, regulators and companies "
+"Used by public organizations, academic researchers, regulators and companies "
 "around the world to understand the health of the Internet."
 msgstr ""
 "برای فهم سلامت اینترنت توسط سازمان‌های عمومی، محققان دانشگاهی، رگولاتورها و "

--- a/translations/languages/fr.po
+++ b/translations/languages/fr.po
@@ -46,7 +46,7 @@ msgstr "Groupe de discussion et de notification"
 
 #: measure.html:97
 msgid ""
-"Distributed infrastructure and large user base provides an open, verifiable "
+"Distributed infrastructure and large user base provide an open, verifiable "
 "measurement platform for global network performance."
 msgstr ""
 "Une infrastructure distribuée et un vaste parc d'utilisateurs fournissent "
@@ -212,7 +212,7 @@ msgstr "Téléversement"
 
 #: measure.html:102
 msgid ""
-"Used by public organization, academic researchers, regulators and companies "
+"Used by public organizations, academic researchers, regulators and companies "
 "around the world to understand the health of the Internet."
 msgstr ""
 "Utilisé par des organismes publics, des chercheurs universitaires, des "

--- a/translations/languages/hi.po
+++ b/translations/languages/hi.po
@@ -45,7 +45,7 @@ msgstr "चर्चा और सूचना समूह"
 
 #: measure.html:97
 msgid ""
-"Distributed infrastructure and large user base provides an open, verifiable "
+"Distributed infrastructure and large user base provide an open, verifiable "
 "measurement platform for global network performance."
 msgstr ""
 "वितरित अवसंरचना और बड़े उपयोगकर्ता आधार वैश्विक नेटवर्क के प्रदर्शन के लिए "
@@ -204,7 +204,7 @@ msgstr "अपलोड करें"
 
 #: measure.html:102
 msgid ""
-"Used by public organization, academic researchers, regulators and companies "
+"Used by public organizations, academic researchers, regulators and companies "
 "around the world to understand the health of the Internet."
 msgstr ""
 "इंटरनेट के स्वास्थ्य को समझने के लिए सार्वजनिक संगठन, शैक्षिक शोधकर्ताओं, "

--- a/translations/languages/id.po
+++ b/translations/languages/id.po
@@ -45,7 +45,7 @@ msgstr "Diskusi dan Notifikasi Grup"
 
 #: measure.html:97
 msgid ""
-"Distributed infrastructure and large user base provides an open, verifiable "
+"Distributed infrastructure and large user base provide an open, verifiable "
 "measurement platform for global network performance."
 msgstr ""
 "Infrastruktur terdistribusi dan basis pengguna yang besar menyediakan "
@@ -206,7 +206,7 @@ msgstr "Unggah"
 
 #: measure.html:102
 msgid ""
-"Used by public organization, academic researchers, regulators and companies "
+"Used by public organizations, academic researchers, regulators and companies "
 "around the world to understand the health of the Internet."
 msgstr ""
 "Digunakan oleh organisasi publik, peneliti akademik, regulator dan "

--- a/translations/languages/nl.po
+++ b/translations/languages/nl.po
@@ -47,7 +47,7 @@ msgstr "Discussie- en meldingengroep"
 
 #: measure.html:97
 msgid ""
-"Distributed infrastructure and large user base provides an open, verifiable "
+"Distributed infrastructure and large user base provide an open, verifiable "
 "measurement platform for global network performance."
 msgstr ""
 "Gedeelde infrastructuur en een groot aantal gebruikers zorgt voor een open, "
@@ -207,7 +207,7 @@ msgstr "Uploaden"
 
 #: measure.html:102
 msgid ""
-"Used by public organization, academic researchers, regulators and companies "
+"Used by public organizations, academic researchers, regulators and companies "
 "around the world to understand the health of the Internet."
 msgstr ""
 "Gebruikt door publieke organisaties, academische onderzoekers, regelgevende "

--- a/translations/languages/ru.po
+++ b/translations/languages/ru.po
@@ -45,7 +45,7 @@ msgstr "Группа для обсуждений и уведомлений"
 
 #: measure.html:97
 msgid ""
-"Distributed infrastructure and large user base provides an open, verifiable "
+"Distributed infrastructure and large user base provide an open, verifiable "
 "measurement platform for global network performance."
 msgstr ""
 "Распространяемая инфраструктура и большая пользовательская база обеспечивают"
@@ -208,7 +208,7 @@ msgstr "Загрузить "
 
 #: measure.html:102
 msgid ""
-"Used by public organization, academic researchers, regulators and companies "
+"Used by public organizations, academic researchers, regulators and companies "
 "around the world to understand the health of the Internet."
 msgstr ""
 "Используется общественной организацией, академическими исследователями, "

--- a/translations/languages/zh.po
+++ b/translations/languages/zh.po
@@ -43,7 +43,7 @@ msgstr "討論與公告群組"
 
 #: measure.html:97
 msgid ""
-"Distributed infrastructure and large user base provides an open, verifiable "
+"Distributed infrastructure and large user base provide an open, verifiable "
 "measurement platform for global network performance."
 msgstr "分散式的基礎設施和大型用戶基礎提供了一個開放、可查證的測量平台來了解全球的網路表現。"
 
@@ -192,7 +192,7 @@ msgstr "上傳"
 
 #: measure.html:102
 msgid ""
-"Used by public organization, academic researchers, regulators and companies "
+"Used by public organizations, academic researchers, regulators and companies "
 "around the world to understand the health of the Internet."
 msgstr "由全球的公共組織、學術研究人員、執法者以及商業公司利用來了解網際網路的健康狀況。"
 

--- a/translations/source/application.pot
+++ b/translations/source/application.pot
@@ -35,7 +35,7 @@ msgid "Discussion and Notification Group"
 msgstr ""
 
 #: measure.html:100
-msgid "Distributed infrastructure and large user base provides an open, verifiable measurement platform for global network performance."
+msgid "Distributed infrastructure and large user base provide an open, verifiable measurement platform for global network performance."
 msgstr ""
 
 #: measure.html:57
@@ -166,7 +166,7 @@ msgid "Upload"
 msgstr ""
 
 #: measure.html:105
-msgid "Used by public organization, academic researchers, regulators and companies around the world to understand the health of the Internet."
+msgid "Used by public organizations, academic researchers, regulators and companies around the world to understand the health of the Internet."
 msgstr ""
 
 #: measure.html:121


### PR DESCRIPTION
Fixed four spelling and grammar issues found across the codebase:

1. **README.md line 24**: `langugage` → `language` (misspelling)
2. **README.md line 30**: Wrong translation file reference `it.js` → `nl.js` in the example that copies from the Dutch (`nl`) folder — would confuse anyone following the guide
3. **measure.html, .pot, all .po files**: `public organization` → `public organizations` — inconsistent with surrounding plural nouns in the same sentence
4. **measure.html, .pot, all .po files**: Subject-verb agreement — `infrastructure and large user base provides` → `provide` (compound subject takes plural verb)