### PR TITLE
fix: remove unreachable cb() calls from translations and pot tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,31 +4,28 @@ var gettext = require('gulp-angular-gettext');
 
 function inject(cb) {
   gulp.src('www/index.html')
-  .pipe(inject(gulp.src('www/translations/scripts/*.js', {read: false}), {relative: true, name: 'translations'}))
-  .pipe(gulp.dest('www'));
+    .pipe(inject(gulp.src('www/translations/scripts/*.js', { read: false }), { relative: true, name: 'translations' }))
+    .pipe(gulp.dest('www'));
 
   cb();
 };
 
-function translations(cb) {
+function translations() {
   return gulp.src('translations/languages/*.po')
-  .pipe(gettext.compile())
-  .pipe(gulp.dest('app/assets/translations/'));
-  cb();
+    .pipe(gettext.compile())
+    .pipe(gulp.dest('app/assets/translations/'));
 };
 
-function pot(cb) {
+function pot() {
   return gulp.src([
     'app/measure/*.js',
     'app/measure/*.html',
     'app/index.html',
   ])
-  .pipe(gettext.extract('application.pot', {
-    // options to pass to angular-gettext-tools...
-  }))
-  .pipe(gulp.dest('translations/source'));
-
-  cb();
+    .pipe(gettext.extract('application.pot', {
+      // options to pass to angular-gettext-tools...
+    }))
+    .pipe(gulp.dest('translations/source'));
 };
 
 // Copy dependencies to ./public/libs/
@@ -36,7 +33,7 @@ function copy_libs(cb) {
   // Copy all the libraries under @bower_components to libraries/.
   gulp.src([
     "./node_modules/@bower_components/**/*.**",
-  ], {base: "./node_modules/@bower_components"})
+  ], { base: "./node_modules/@bower_components" })
     .pipe(gulp.dest('./app/libraries'));
 
   // Copy the @m-lab js files to libraries/.
@@ -45,7 +42,7 @@ function copy_libs(cb) {
     "./node_modules/@m-lab/msak/dist/*.min.js",
   ])
 
-  .pipe(gulp.dest('./app/libraries'));
+    .pipe(gulp.dest('./app/libraries'));
 
   gulp.src([
     "./node_modules/ua-device-detector/ua-device-detector.min.js",


### PR DESCRIPTION
## Summary
Fixes the unreachable `cb()` dead code in `translations` and `pot` tasks reported in #2.

## Changes
- Removed `cb` parameter from `translations` function signature
- Removed unreachable `cb()` call from `translations`
- Removed `cb` parameter from `pot` function signature
- Removed unreachable `cb()` call from `pot`
- Both functions now rely on the returned stream for Gulp 4 task completion, which is the correct approach

## Type of Change
- [x] Bug fix

## Testing
- [x] Ran `gulp translations` — completes without hanging
- [x] Ran `gulp pot` — completes without hanging

## Related Issue
Fixes - 123