### PR TITLE
fix: replace dead Universal Analytics snippet with GA4 in all 11 language subpages

### DIFF
--- a/app/az/index.html
+++ b/app/az/index.html
@@ -5,76 +5,79 @@
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
 <html ng-app="Measure">
-	<head>
-		<title>Speed Test by Measurement Lab</title>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<link rel="icon" href="/assets/images/mlab_logo_m.ico">
-		<link rel="stylesheet" href="/assets/css/main.css" />
-	</head>
-    <script>
-		const INTERFACE_LANGUAGE = 'az';
-	</script>
-	<body>
 
-		<!-- Sidebar -->
-		<section id="sidebar">
-			<div class="inner">
-				<nav>
-					<ul>
-						<li><a href="#intro" class="active" translate>Measure</a></li>
-						<li><a href="#about" translate>About</a></li>
-						<li><a href="#contact" translate>Contact</a></li>
-					</ul>
-				</nav>
-			</div>
-		</section>
+<head>
+	<title>Speed Test by Measurement Lab</title>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<link rel="icon" href="/assets/images/mlab_logo_m.ico">
+	<link rel="stylesheet" href="/assets/css/main.css" />
+</head>
+<script>
+	const INTERFACE_LANGUAGE = 'az';
+</script>
 
-		<!-- Wrapper -->
-		<div id="wrapper" ng-view></div>
+<body>
 
-		<!-- Footer -->
-		<footer id="footer" class="wrapper style1-alt">
-			<div class="inner">
-				<ul class="menu">
-					<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
-					<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
-					<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+	<!-- Sidebar -->
+	<section id="sidebar">
+		<div class="inner">
+			<nav>
+				<ul>
+					<li><a href="#intro" class="active" translate>Measure</a></li>
+					<li><a href="#about" translate>About</a></li>
+					<li><a href="#contact" translate>Contact</a></li>
 				</ul>
-			</div>
-		</footer>
+			</nav>
+		</div>
+	</section>
 
-		<!-- Scripts -->
+	<!-- Wrapper -->
+	<div id="wrapper" ng-view></div>
 
-		<script src="/libraries/html5-boilerplate/dist/js/vendor/modernizr-2.8.3.min.js"></script>
-		<script src="/libraries/angular/angular.js"></script>
-	  <script src="/libraries/angular-route/angular-route.js"></script>
-	  <script src="/libraries/angular-gettext/dist/angular-gettext.min.js"></script>
-	  <script src="/libraries/jquery/dist/jquery.min.js"></script>
-		<script src="/libraries/skel/dist/skel.min.js"></script>
+	<!-- Footer -->
+	<footer id="footer" class="wrapper style1-alt">
+		<div class="inner">
+			<ul class="menu">
+				<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
+				<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
+				<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+			</ul>
+		</div>
+	</footer>
 
-		<script src="/assets/js/jquery.scrollex.min.js"></script>
-		<script src="/assets/js/jquery.scrolly.min.js"></script>
-		<script src="/assets/js/util.js"></script>
-		<script src="/assets/js/main.js"></script>
+	<!-- Scripts -->
 
-	  <script type="text/javascript" src="/libraries/ndt7.js"></script>
-	  <script type="text/javascript" src="/libraries/re-tree.min.js"></script>
-	  <script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
-	  <script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+	<script src="/libraries/html5-boilerplate/dist/js/vendor/modernizr-2.8.3.min.js"></script>
+	<script src="/libraries/angular/angular.js"></script>
+	<script src="/libraries/angular-route/angular-route.js"></script>
+	<script src="/libraries/angular-gettext/dist/angular-gettext.min.js"></script>
+	<script src="/libraries/jquery/dist/jquery.min.js"></script>
+	<script src="/libraries/skel/dist/skel.min.js"></script>
 
-      <script src="/assets/translations/az.js"></script>
-	  <script src="/measure/measure.js"></script>
-	  <script src="/services/gaugeService.js"></script>
-	  <script src="/app.js"></script>
-	  <script>
-	   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-	   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-	   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-	   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	<script src="/assets/js/jquery.scrollex.min.js"></script>
+	<script src="/assets/js/jquery.scrolly.min.js"></script>
+	<script src="/assets/js/util.js"></script>
+	<script src="/assets/js/main.js"></script>
 
-	   ga('create', 'UA-56251309-2', 'auto');
-	   ga('send', 'pageview');
-	  </script>
-	</body>
+	<script type="text/javascript" src="/libraries/ndt7.js"></script>
+	<script type="text/javascript" src="/libraries/re-tree.min.js"></script>
+	<script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
+	<script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+
+	<script src="/assets/translations/az.js"></script>
+	<script src="/measure/measure.js"></script>
+	<script src="/services/gaugeService.js"></script>
+	<script src="/app.js"></script>
+	<!-- Google tag (gtag.js) -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id=G-WV41BWS391"></script>
+	<script>
+		window.dataLayer = window.dataLayer || [];
+		function gtag() { dataLayer.push(arguments); }
+		gtag('js', new Date());
+
+		gtag('config', 'G-WV41BWS391');
+	</script>
+</body>
+
 </html>

--- a/app/de/index.html
+++ b/app/de/index.html
@@ -5,76 +5,79 @@
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
 <html ng-app="Measure">
-	<head>
-		<title>Speed Test by Measurement Lab</title>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<link rel="icon" href="/assets/images/mlab_logo_m.ico">
-		<link rel="stylesheet" href="/assets/css/main.css" />
-	</head>
-    <script>
-		const INTERFACE_LANGUAGE = 'de_DE';
-	</script>
-	<body>
 
-		<!-- Sidebar -->
-		<section id="sidebar">
-			<div class="inner">
-				<nav>
-					<ul>
-						<li><a href="#intro" class="active" translate>Measure</a></li>
-						<li><a href="#about" translate>About</a></li>
-						<li><a href="#contact" translate>Contact</a></li>
-					</ul>
-				</nav>
-			</div>
-		</section>
+<head>
+	<title>Speed Test by Measurement Lab</title>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<link rel="icon" href="/assets/images/mlab_logo_m.ico">
+	<link rel="stylesheet" href="/assets/css/main.css" />
+</head>
+<script>
+	const INTERFACE_LANGUAGE = 'de_DE';
+</script>
 
-		<!-- Wrapper -->
-		<div id="wrapper" ng-view></div>
+<body>
 
-		<!-- Footer -->
-		<footer id="footer" class="wrapper style1-alt">
-			<div class="inner">
-				<ul class="menu">
-					<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
-					<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
-					<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+	<!-- Sidebar -->
+	<section id="sidebar">
+		<div class="inner">
+			<nav>
+				<ul>
+					<li><a href="#intro" class="active" translate>Measure</a></li>
+					<li><a href="#about" translate>About</a></li>
+					<li><a href="#contact" translate>Contact</a></li>
 				</ul>
-			</div>
-		</footer>
+			</nav>
+		</div>
+	</section>
 
-		<!-- Scripts -->
+	<!-- Wrapper -->
+	<div id="wrapper" ng-view></div>
 
-		<script src="/libraries/html5-boilerplate/dist/js/vendor/modernizr-2.8.3.min.js"></script>
-		<script src="/libraries/angular/angular.js"></script>
-	  <script src="/libraries/angular-route/angular-route.js"></script>
-	  <script src="/libraries/angular-gettext/dist/angular-gettext.min.js"></script>
-	  <script src="/libraries/jquery/dist/jquery.min.js"></script>
-		<script src="/libraries/skel/dist/skel.min.js"></script>
+	<!-- Footer -->
+	<footer id="footer" class="wrapper style1-alt">
+		<div class="inner">
+			<ul class="menu">
+				<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
+				<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
+				<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+			</ul>
+		</div>
+	</footer>
 
-		<script src="/assets/js/jquery.scrollex.min.js"></script>
-		<script src="/assets/js/jquery.scrolly.min.js"></script>
-		<script src="/assets/js/util.js"></script>
-		<script src="/assets/js/main.js"></script>
+	<!-- Scripts -->
 
-	  <script type="text/javascript" src="/libraries/ndt7.js"></script>
-	  <script type="text/javascript" src="/libraries/re-tree.min.js"></script>
-	  <script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
-	  <script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+	<script src="/libraries/html5-boilerplate/dist/js/vendor/modernizr-2.8.3.min.js"></script>
+	<script src="/libraries/angular/angular.js"></script>
+	<script src="/libraries/angular-route/angular-route.js"></script>
+	<script src="/libraries/angular-gettext/dist/angular-gettext.min.js"></script>
+	<script src="/libraries/jquery/dist/jquery.min.js"></script>
+	<script src="/libraries/skel/dist/skel.min.js"></script>
 
-      <script src="/assets/translations/de_DE.js"></script>
-	  <script src="/measure/measure.js"></script>
-	  <script src="/services/gaugeService.js"></script>
-	  <script src="/app.js"></script>
-	  <script>
-	   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-	   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-	   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-	   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	<script src="/assets/js/jquery.scrollex.min.js"></script>
+	<script src="/assets/js/jquery.scrolly.min.js"></script>
+	<script src="/assets/js/util.js"></script>
+	<script src="/assets/js/main.js"></script>
 
-	   ga('create', 'UA-56251309-2', 'auto');
-	   ga('send', 'pageview');
-	  </script>
-	</body>
+	<script type="text/javascript" src="/libraries/ndt7.js"></script>
+	<script type="text/javascript" src="/libraries/re-tree.min.js"></script>
+	<script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
+	<script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+
+	<script src="/assets/translations/de_DE.js"></script>
+	<script src="/measure/measure.js"></script>
+	<script src="/services/gaugeService.js"></script>
+	<script src="/app.js"></script>
+	<!-- Google tag (gtag.js) -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id=G-WV41BWS391"></script>
+	<script>
+		window.dataLayer = window.dataLayer || [];
+		function gtag() { dataLayer.push(arguments); }
+		gtag('js', new Date());
+
+		gtag('config', 'G-WV41BWS391');
+	</script>
+</body>
+
 </html>

--- a/app/el/index.html
+++ b/app/el/index.html
@@ -5,76 +5,79 @@
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
 <html ng-app="Measure">
-	<head>
-		<title>Speed Test by Measurement Lab</title>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<link rel="icon" href="/assets/images/mlab_logo_m.ico">
-		<link rel="stylesheet" href="/assets/css/main.css" />
-	</head>
-    <script>
-		const INTERFACE_LANGUAGE = 'el';
-	</script>
-	<body>
 
-		<!-- Sidebar -->
-		<section id="sidebar">
-			<div class="inner">
-				<nav>
-					<ul>
-						<li><a href="#intro" class="active" translate>Measure</a></li>
-						<li><a href="#about" translate>About</a></li>
-						<li><a href="#contact" translate>Contact</a></li>
-					</ul>
-				</nav>
-			</div>
-		</section>
+<head>
+	<title>Speed Test by Measurement Lab</title>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<link rel="icon" href="/assets/images/mlab_logo_m.ico">
+	<link rel="stylesheet" href="/assets/css/main.css" />
+</head>
+<script>
+	const INTERFACE_LANGUAGE = 'el';
+</script>
 
-		<!-- Wrapper -->
-		<div id="wrapper" ng-view></div>
+<body>
 
-		<!-- Footer -->
-		<footer id="footer" class="wrapper style1-alt">
-			<div class="inner">
-				<ul class="menu">
-					<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
-					<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
-					<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+	<!-- Sidebar -->
+	<section id="sidebar">
+		<div class="inner">
+			<nav>
+				<ul>
+					<li><a href="#intro" class="active" translate>Measure</a></li>
+					<li><a href="#about" translate>About</a></li>
+					<li><a href="#contact" translate>Contact</a></li>
 				</ul>
-			</div>
-		</footer>
+			</nav>
+		</div>
+	</section>
 
-		<!-- Scripts -->
+	<!-- Wrapper -->
+	<div id="wrapper" ng-view></div>
 
-		<script src="/libraries/html5-boilerplate/dist/js/vendor/modernizr-2.8.3.min.js"></script>
-		<script src="/libraries/angular/angular.js"></script>
-	  <script src="/libraries/angular-route/angular-route.js"></script>
-	  <script src="/libraries/angular-gettext/dist/angular-gettext.min.js"></script>
-	  <script src="/libraries/jquery/dist/jquery.min.js"></script>
-		<script src="/libraries/skel/dist/skel.min.js"></script>
+	<!-- Footer -->
+	<footer id="footer" class="wrapper style1-alt">
+		<div class="inner">
+			<ul class="menu">
+				<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
+				<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
+				<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+			</ul>
+		</div>
+	</footer>
 
-		<script src="/assets/js/jquery.scrollex.min.js"></script>
-		<script src="/assets/js/jquery.scrolly.min.js"></script>
-		<script src="/assets/js/util.js"></script>
-		<script src="/assets/js/main.js"></script>
+	<!-- Scripts -->
 
-	  <script type="text/javascript" src="/libraries/ndt7.js"></script>
-	  <script type="text/javascript" src="/libraries/re-tree.min.js"></script>
-	  <script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
-	  <script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+	<script src="/libraries/html5-boilerplate/dist/js/vendor/modernizr-2.8.3.min.js"></script>
+	<script src="/libraries/angular/angular.js"></script>
+	<script src="/libraries/angular-route/angular-route.js"></script>
+	<script src="/libraries/angular-gettext/dist/angular-gettext.min.js"></script>
+	<script src="/libraries/jquery/dist/jquery.min.js"></script>
+	<script src="/libraries/skel/dist/skel.min.js"></script>
 
-      <script src="/assets/translations/el.js"></script>
-	  <script src="/measure/measure.js"></script>
-	  <script src="/services/gaugeService.js"></script>
-	  <script src="/app.js"></script>
-	  <script>
-	   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-	   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-	   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-	   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	<script src="/assets/js/jquery.scrollex.min.js"></script>
+	<script src="/assets/js/jquery.scrolly.min.js"></script>
+	<script src="/assets/js/util.js"></script>
+	<script src="/assets/js/main.js"></script>
 
-	   ga('create', 'UA-56251309-2', 'auto');
-	   ga('send', 'pageview');
-	  </script>
-	</body>
+	<script type="text/javascript" src="/libraries/ndt7.js"></script>
+	<script type="text/javascript" src="/libraries/re-tree.min.js"></script>
+	<script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
+	<script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+
+	<script src="/assets/translations/el.js"></script>
+	<script src="/measure/measure.js"></script>
+	<script src="/services/gaugeService.js"></script>
+	<script src="/app.js"></script>
+	<!-- Google tag (gtag.js) -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id=G-WV41BWS391"></script>
+	<script>
+		window.dataLayer = window.dataLayer || [];
+		function gtag() { dataLayer.push(arguments); }
+		gtag('js', new Date());
+
+		gtag('config', 'G-WV41BWS391');
+	</script>
+</body>
+
 </html>

--- a/app/es/index.html
+++ b/app/es/index.html
@@ -5,76 +5,79 @@
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
 <html ng-app="Measure">
-	<head>
-		<title>Speed Test by Measurement Lab</title>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<link rel="icon" href="/assets/images/mlab_logo_m.ico">
-		<link rel="stylesheet" href="/assets/css/main.css" />
-	</head>
-    <script>
-		const INTERFACE_LANGUAGE = 'es';
-	</script>
-	<body>
 
-		<!-- Sidebar -->
-		<section id="sidebar">
-			<div class="inner">
-				<nav>
-					<ul>
-						<li><a href="#intro" class="active" translate>Measure</a></li>
-						<li><a href="#about" translate>About</a></li>
-						<li><a href="#contact" translate>Contact</a></li>
-					</ul>
-				</nav>
-			</div>
-		</section>
+<head>
+	<title>Speed Test by Measurement Lab</title>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<link rel="icon" href="/assets/images/mlab_logo_m.ico">
+	<link rel="stylesheet" href="/assets/css/main.css" />
+</head>
+<script>
+	const INTERFACE_LANGUAGE = 'es';
+</script>
 
-		<!-- Wrapper -->
-		<div id="wrapper" ng-view></div>
+<body>
 
-		<!-- Footer -->
-		<footer id="footer" class="wrapper style1-alt">
-			<div class="inner">
-				<ul class="menu">
-					<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
-					<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
-					<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+	<!-- Sidebar -->
+	<section id="sidebar">
+		<div class="inner">
+			<nav>
+				<ul>
+					<li><a href="#intro" class="active" translate>Measure</a></li>
+					<li><a href="#about" translate>About</a></li>
+					<li><a href="#contact" translate>Contact</a></li>
 				</ul>
-			</div>
-		</footer>
+			</nav>
+		</div>
+	</section>
 
-		<!-- Scripts -->
+	<!-- Wrapper -->
+	<div id="wrapper" ng-view></div>
 
-		<script src="/libraries/html5-boilerplate/dist/js/vendor/modernizr-2.8.3.min.js"></script>
-		<script src="/libraries/angular/angular.js"></script>
-	  <script src="/libraries/angular-route/angular-route.js"></script>
-	  <script src="/libraries/angular-gettext/dist/angular-gettext.min.js"></script>
-	  <script src="/libraries/jquery/dist/jquery.min.js"></script>
-		<script src="/libraries/skel/dist/skel.min.js"></script>
+	<!-- Footer -->
+	<footer id="footer" class="wrapper style1-alt">
+		<div class="inner">
+			<ul class="menu">
+				<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
+				<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
+				<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+			</ul>
+		</div>
+	</footer>
 
-		<script src="/assets/js/jquery.scrollex.min.js"></script>
-		<script src="/assets/js/jquery.scrolly.min.js"></script>
-		<script src="/assets/js/util.js"></script>
-		<script src="/assets/js/main.js"></script>
+	<!-- Scripts -->
 
-	  <script type="text/javascript" src="/libraries/ndt7.js"></script>
-	  <script type="text/javascript" src="/libraries/re-tree.min.js"></script>
-	  <script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
-	  <script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+	<script src="/libraries/html5-boilerplate/dist/js/vendor/modernizr-2.8.3.min.js"></script>
+	<script src="/libraries/angular/angular.js"></script>
+	<script src="/libraries/angular-route/angular-route.js"></script>
+	<script src="/libraries/angular-gettext/dist/angular-gettext.min.js"></script>
+	<script src="/libraries/jquery/dist/jquery.min.js"></script>
+	<script src="/libraries/skel/dist/skel.min.js"></script>
 
-      <script src="/assets/translations/es.js"></script>
-	  <script src="/measure/measure.js"></script>
-	  <script src="/services/gaugeService.js"></script>
-	  <script src="/app.js"></script>
-	  <script>
-	   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-	   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-	   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-	   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	<script src="/assets/js/jquery.scrollex.min.js"></script>
+	<script src="/assets/js/jquery.scrolly.min.js"></script>
+	<script src="/assets/js/util.js"></script>
+	<script src="/assets/js/main.js"></script>
 
-	   ga('create', 'UA-56251309-2', 'auto');
-	   ga('send', 'pageview');
-	  </script>
-	</body>
+	<script type="text/javascript" src="/libraries/ndt7.js"></script>
+	<script type="text/javascript" src="/libraries/re-tree.min.js"></script>
+	<script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
+	<script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+
+	<script src="/assets/translations/es.js"></script>
+	<script src="/measure/measure.js"></script>
+	<script src="/services/gaugeService.js"></script>
+	<script src="/app.js"></script>
+	<!-- Google tag (gtag.js) -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id=G-WV41BWS391"></script>
+	<script>
+		window.dataLayer = window.dataLayer || [];
+		function gtag() { dataLayer.push(arguments); }
+		gtag('js', new Date());
+
+		gtag('config', 'G-WV41BWS391');
+	</script>
+</body>
+
 </html>

--- a/app/fa/index.html
+++ b/app/fa/index.html
@@ -5,76 +5,79 @@
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
 <html ng-app="Measure">
-	<head>
-		<title>Speed Test by Measurement Lab</title>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<link rel="icon" href="/assets/images/mlab_logo_m.ico">
-		<link rel="stylesheet" href="/assets/css/main.css" />
-	</head>
-    <script>
-		const INTERFACE_LANGUAGE = 'fa';
-	</script>
-	<body>
 
-		<!-- Sidebar -->
-		<section id="sidebar">
-			<div class="inner">
-				<nav>
-					<ul>
-						<li><a href="#intro" class="active" translate>Measure</a></li>
-						<li><a href="#about" translate>About</a></li>
-						<li><a href="#contact" translate>Contact</a></li>
-					</ul>
-				</nav>
-			</div>
-		</section>
+<head>
+	<title>Speed Test by Measurement Lab</title>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<link rel="icon" href="/assets/images/mlab_logo_m.ico">
+	<link rel="stylesheet" href="/assets/css/main.css" />
+</head>
+<script>
+	const INTERFACE_LANGUAGE = 'fa';
+</script>
 
-		<!-- Wrapper -->
-		<div id="wrapper" ng-view></div>
+<body>
 
-		<!-- Footer -->
-		<footer id="footer" class="wrapper style1-alt">
-			<div class="inner">
-				<ul class="menu">
-					<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
-					<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
-					<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+	<!-- Sidebar -->
+	<section id="sidebar">
+		<div class="inner">
+			<nav>
+				<ul>
+					<li><a href="#intro" class="active" translate>Measure</a></li>
+					<li><a href="#about" translate>About</a></li>
+					<li><a href="#contact" translate>Contact</a></li>
 				</ul>
-			</div>
-		</footer>
+			</nav>
+		</div>
+	</section>
 
-		<!-- Scripts -->
+	<!-- Wrapper -->
+	<div id="wrapper" ng-view></div>
 
-		<script src="/libraries/html5-boilerplate/dist/js/vendor/modernizr-2.8.3.min.js"></script>
-		<script src="/libraries/angular/angular.js"></script>
-	  <script src="/libraries/angular-route/angular-route.js"></script>
-	  <script src="/libraries/angular-gettext/dist/angular-gettext.min.js"></script>
-	  <script src="/libraries/jquery/dist/jquery.min.js"></script>
-		<script src="/libraries/skel/dist/skel.min.js"></script>
+	<!-- Footer -->
+	<footer id="footer" class="wrapper style1-alt">
+		<div class="inner">
+			<ul class="menu">
+				<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
+				<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
+				<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+			</ul>
+		</div>
+	</footer>
 
-		<script src="/assets/js/jquery.scrollex.min.js"></script>
-		<script src="/assets/js/jquery.scrolly.min.js"></script>
-		<script src="/assets/js/util.js"></script>
-		<script src="/assets/js/main.js"></script>
+	<!-- Scripts -->
 
-	  <script type="text/javascript" src="/libraries/ndt7.js"></script>
-	  <script type="text/javascript" src="/libraries/re-tree.min.js"></script>
-	  <script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
-	  <script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+	<script src="/libraries/html5-boilerplate/dist/js/vendor/modernizr-2.8.3.min.js"></script>
+	<script src="/libraries/angular/angular.js"></script>
+	<script src="/libraries/angular-route/angular-route.js"></script>
+	<script src="/libraries/angular-gettext/dist/angular-gettext.min.js"></script>
+	<script src="/libraries/jquery/dist/jquery.min.js"></script>
+	<script src="/libraries/skel/dist/skel.min.js"></script>
 
-      <script src="/assets/translations/fa.js"></script>
-	  <script src="/measure/measure.js"></script>
-	  <script src="/services/gaugeService.js"></script>
-	  <script src="/app.js"></script>
-	  <script>
-	   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-	   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-	   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-	   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	<script src="/assets/js/jquery.scrollex.min.js"></script>
+	<script src="/assets/js/jquery.scrolly.min.js"></script>
+	<script src="/assets/js/util.js"></script>
+	<script src="/assets/js/main.js"></script>
 
-	   ga('create', 'UA-56251309-2', 'auto');
-	   ga('send', 'pageview');
-	  </script>
-	</body>
+	<script type="text/javascript" src="/libraries/ndt7.js"></script>
+	<script type="text/javascript" src="/libraries/re-tree.min.js"></script>
+	<script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
+	<script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+
+	<script src="/assets/translations/fa.js"></script>
+	<script src="/measure/measure.js"></script>
+	<script src="/services/gaugeService.js"></script>
+	<script src="/app.js"></script>
+	<!-- Google tag (gtag.js) -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id=G-WV41BWS391"></script>
+	<script>
+		window.dataLayer = window.dataLayer || [];
+		function gtag() { dataLayer.push(arguments); }
+		gtag('js', new Date());
+
+		gtag('config', 'G-WV41BWS391');
+	</script>
+</body>
+
 </html>

--- a/app/fr/index.html
+++ b/app/fr/index.html
@@ -5,76 +5,79 @@
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
 <html ng-app="Measure">
-	<head>
-		<title>Speed Test by Measurement Lab</title>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<link rel="icon" href="/assets/images/mlab_logo_m.ico">
-		<link rel="stylesheet" href="/assets/css/main.css" />
-	</head>
-    <script>
-		const INTERFACE_LANGUAGE = 'fr';
-	</script>
-	<body>
 
-		<!-- Sidebar -->
-		<section id="sidebar">
-			<div class="inner">
-				<nav>
-					<ul>
-						<li><a href="#intro" class="active" translate>Measure</a></li>
-						<li><a href="#about" translate>About</a></li>
-						<li><a href="#contact" translate>Contact</a></li>
-					</ul>
-				</nav>
-			</div>
-		</section>
+<head>
+	<title>Speed Test by Measurement Lab</title>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<link rel="icon" href="/assets/images/mlab_logo_m.ico">
+	<link rel="stylesheet" href="/assets/css/main.css" />
+</head>
+<script>
+	const INTERFACE_LANGUAGE = 'fr';
+</script>
 
-		<!-- Wrapper -->
-		<div id="wrapper" ng-view></div>
+<body>
 
-		<!-- Footer -->
-		<footer id="footer" class="wrapper style1-alt">
-			<div class="inner">
-				<ul class="menu">
-					<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
-					<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
-					<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+	<!-- Sidebar -->
+	<section id="sidebar">
+		<div class="inner">
+			<nav>
+				<ul>
+					<li><a href="#intro" class="active" translate>Measure</a></li>
+					<li><a href="#about" translate>About</a></li>
+					<li><a href="#contact" translate>Contact</a></li>
 				</ul>
-			</div>
-		</footer>
+			</nav>
+		</div>
+	</section>
 
-		<!-- Scripts -->
+	<!-- Wrapper -->
+	<div id="wrapper" ng-view></div>
 
-		<script src="/libraries/html5-boilerplate/dist/js/vendor/modernizr-2.8.3.min.js"></script>
-		<script src="/libraries/angular/angular.js"></script>
-	  <script src="/libraries/angular-route/angular-route.js"></script>
-	  <script src="/libraries/angular-gettext/dist/angular-gettext.min.js"></script>
-	  <script src="/libraries/jquery/dist/jquery.min.js"></script>
-		<script src="/libraries/skel/dist/skel.min.js"></script>
+	<!-- Footer -->
+	<footer id="footer" class="wrapper style1-alt">
+		<div class="inner">
+			<ul class="menu">
+				<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
+				<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
+				<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+			</ul>
+		</div>
+	</footer>
 
-		<script src="/assets/js/jquery.scrollex.min.js"></script>
-		<script src="/assets/js/jquery.scrolly.min.js"></script>
-		<script src="/assets/js/util.js"></script>
-		<script src="/assets/js/main.js"></script>
+	<!-- Scripts -->
 
-	  <script type="text/javascript" src="/libraries/ndt7.js"></script>
-	  <script type="text/javascript" src="/libraries/re-tree.min.js"></script>
-	  <script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
-	  <script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+	<script src="/libraries/html5-boilerplate/dist/js/vendor/modernizr-2.8.3.min.js"></script>
+	<script src="/libraries/angular/angular.js"></script>
+	<script src="/libraries/angular-route/angular-route.js"></script>
+	<script src="/libraries/angular-gettext/dist/angular-gettext.min.js"></script>
+	<script src="/libraries/jquery/dist/jquery.min.js"></script>
+	<script src="/libraries/skel/dist/skel.min.js"></script>
 
-      <script src="/assets/translations/fr.js"></script>
-	  <script src="/measure/measure.js"></script>
-	  <script src="/services/gaugeService.js"></script>
-	  <script src="/app.js"></script>
-	  <script>
-	   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-	   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-	   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-	   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	<script src="/assets/js/jquery.scrollex.min.js"></script>
+	<script src="/assets/js/jquery.scrolly.min.js"></script>
+	<script src="/assets/js/util.js"></script>
+	<script src="/assets/js/main.js"></script>
 
-	   ga('create', 'UA-56251309-2', 'auto');
-	   ga('send', 'pageview');
-	  </script>
-	</body>
+	<script type="text/javascript" src="/libraries/ndt7.js"></script>
+	<script type="text/javascript" src="/libraries/re-tree.min.js"></script>
+	<script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
+	<script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+
+	<script src="/assets/translations/fr.js"></script>
+	<script src="/measure/measure.js"></script>
+	<script src="/services/gaugeService.js"></script>
+	<script src="/app.js"></script>
+	<!-- Google tag (gtag.js) -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id=G-WV41BWS391"></script>
+	<script>
+		window.dataLayer = window.dataLayer || [];
+		function gtag() { dataLayer.push(arguments); }
+		gtag('js', new Date());
+
+		gtag('config', 'G-WV41BWS391');
+	</script>
+</body>
+
 </html>

--- a/app/hi/index.html
+++ b/app/hi/index.html
@@ -5,76 +5,79 @@
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
 <html ng-app="Measure">
-	<head>
-		<title>Speed Test by Measurement Lab</title>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<link rel="icon" href="/assets/images/mlab_logo_m.ico">
-		<link rel="stylesheet" href="/assets/css/main.css" />
-	</head>
-    <script>
-		const INTERFACE_LANGUAGE = 'hi';
-	</script>
-	<body>
 
-		<!-- Sidebar -->
-		<section id="sidebar">
-			<div class="inner">
-				<nav>
-					<ul>
-						<li><a href="#intro" class="active" translate>Measure</a></li>
-						<li><a href="#about" translate>About</a></li>
-						<li><a href="#contact" translate>Contact</a></li>
-					</ul>
-				</nav>
-			</div>
-		</section>
+<head>
+	<title>Speed Test by Measurement Lab</title>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<link rel="icon" href="/assets/images/mlab_logo_m.ico">
+	<link rel="stylesheet" href="/assets/css/main.css" />
+</head>
+<script>
+	const INTERFACE_LANGUAGE = 'hi';
+</script>
 
-		<!-- Wrapper -->
-		<div id="wrapper" ng-view></div>
+<body>
 
-		<!-- Footer -->
-		<footer id="footer" class="wrapper style1-alt">
-			<div class="inner">
-				<ul class="menu">
-					<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
-					<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
-					<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+	<!-- Sidebar -->
+	<section id="sidebar">
+		<div class="inner">
+			<nav>
+				<ul>
+					<li><a href="#intro" class="active" translate>Measure</a></li>
+					<li><a href="#about" translate>About</a></li>
+					<li><a href="#contact" translate>Contact</a></li>
 				</ul>
-			</div>
-		</footer>
+			</nav>
+		</div>
+	</section>
 
-		<!-- Scripts -->
+	<!-- Wrapper -->
+	<div id="wrapper" ng-view></div>
 
-		<script src="/libraries/html5-boilerplate/dist/js/vendor/modernizr-2.8.3.min.js"></script>
-		<script src="/libraries/angular/angular.js"></script>
-	  <script src="/libraries/angular-route/angular-route.js"></script>
-	  <script src="/libraries/angular-gettext/dist/angular-gettext.min.js"></script>
-	  <script src="/libraries/jquery/dist/jquery.min.js"></script>
-		<script src="/libraries/skel/dist/skel.min.js"></script>
+	<!-- Footer -->
+	<footer id="footer" class="wrapper style1-alt">
+		<div class="inner">
+			<ul class="menu">
+				<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
+				<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
+				<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+			</ul>
+		</div>
+	</footer>
 
-		<script src="/assets/js/jquery.scrollex.min.js"></script>
-		<script src="/assets/js/jquery.scrolly.min.js"></script>
-		<script src="/assets/js/util.js"></script>
-		<script src="/assets/js/main.js"></script>
+	<!-- Scripts -->
 
-	  <script type="text/javascript" src="/libraries/ndt7.js"></script>
-	  <script type="text/javascript" src="/libraries/re-tree.min.js"></script>
-	  <script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
-	  <script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+	<script src="/libraries/html5-boilerplate/dist/js/vendor/modernizr-2.8.3.min.js"></script>
+	<script src="/libraries/angular/angular.js"></script>
+	<script src="/libraries/angular-route/angular-route.js"></script>
+	<script src="/libraries/angular-gettext/dist/angular-gettext.min.js"></script>
+	<script src="/libraries/jquery/dist/jquery.min.js"></script>
+	<script src="/libraries/skel/dist/skel.min.js"></script>
 
-      <script src="/assets/translations/hi.js"></script>
-	  <script src="/measure/measure.js"></script>
-	  <script src="/services/gaugeService.js"></script>
-	  <script src="/app.js"></script>
-	  <script>
-	   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-	   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-	   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-	   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	<script src="/assets/js/jquery.scrollex.min.js"></script>
+	<script src="/assets/js/jquery.scrolly.min.js"></script>
+	<script src="/assets/js/util.js"></script>
+	<script src="/assets/js/main.js"></script>
 
-	   ga('create', 'UA-56251309-2', 'auto');
-	   ga('send', 'pageview');
-	  </script>
-	</body>
+	<script type="text/javascript" src="/libraries/ndt7.js"></script>
+	<script type="text/javascript" src="/libraries/re-tree.min.js"></script>
+	<script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
+	<script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+
+	<script src="/assets/translations/hi.js"></script>
+	<script src="/measure/measure.js"></script>
+	<script src="/services/gaugeService.js"></script>
+	<script src="/app.js"></script>
+	<!-- Google tag (gtag.js) -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id=G-WV41BWS391"></script>
+	<script>
+		window.dataLayer = window.dataLayer || [];
+		function gtag() { dataLayer.push(arguments); }
+		gtag('js', new Date());
+
+		gtag('config', 'G-WV41BWS391');
+	</script>
+</body>
+
 </html>

--- a/app/id/index.html
+++ b/app/id/index.html
@@ -5,76 +5,79 @@
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
 <html ng-app="Measure">
-	<head>
-		<title>Speed Test by Measurement Lab</title>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<link rel="icon" href="/assets/images/mlab_logo_m.ico">
-		<link rel="stylesheet" href="/assets/css/main.css" />
-	</head>
-    <script>
-		const INTERFACE_LANGUAGE = 'id';
-	</script>
-	<body>
 
-		<!-- Sidebar -->
-		<section id="sidebar">
-			<div class="inner">
-				<nav>
-					<ul>
-						<li><a href="#intro" class="active" translate>Measure</a></li>
-						<li><a href="#about" translate>About</a></li>
-						<li><a href="#contact" translate>Contact</a></li>
-					</ul>
-				</nav>
-			</div>
-		</section>
+<head>
+	<title>Speed Test by Measurement Lab</title>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<link rel="icon" href="/assets/images/mlab_logo_m.ico">
+	<link rel="stylesheet" href="/assets/css/main.css" />
+</head>
+<script>
+	const INTERFACE_LANGUAGE = 'id';
+</script>
 
-		<!-- Wrapper -->
-		<div id="wrapper" ng-view></div>
+<body>
 
-		<!-- Footer -->
-		<footer id="footer" class="wrapper style1-alt">
-			<div class="inner">
-				<ul class="menu">
-					<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
-					<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
-					<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+	<!-- Sidebar -->
+	<section id="sidebar">
+		<div class="inner">
+			<nav>
+				<ul>
+					<li><a href="#intro" class="active" translate>Measure</a></li>
+					<li><a href="#about" translate>About</a></li>
+					<li><a href="#contact" translate>Contact</a></li>
 				</ul>
-			</div>
-		</footer>
+			</nav>
+		</div>
+	</section>
 
-		<!-- Scripts -->
+	<!-- Wrapper -->
+	<div id="wrapper" ng-view></div>
 
-		<script src="/libraries/html5-boilerplate/dist/js/vendor/modernizr-2.8.3.min.js"></script>
-		<script src="/libraries/angular/angular.js"></script>
-	  <script src="/libraries/angular-route/angular-route.js"></script>
-	  <script src="/libraries/angular-gettext/dist/angular-gettext.min.js"></script>
-	  <script src="/libraries/jquery/dist/jquery.min.js"></script>
-		<script src="/libraries/skel/dist/skel.min.js"></script>
+	<!-- Footer -->
+	<footer id="footer" class="wrapper style1-alt">
+		<div class="inner">
+			<ul class="menu">
+				<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
+				<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
+				<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+			</ul>
+		</div>
+	</footer>
 
-		<script src="/assets/js/jquery.scrollex.min.js"></script>
-		<script src="/assets/js/jquery.scrolly.min.js"></script>
-		<script src="/assets/js/util.js"></script>
-		<script src="/assets/js/main.js"></script>
+	<!-- Scripts -->
 
-	  <script type="text/javascript" src="/libraries/ndt7.js"></script>
-	  <script type="text/javascript" src="/libraries/re-tree.min.js"></script>
-	  <script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
-	  <script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+	<script src="/libraries/html5-boilerplate/dist/js/vendor/modernizr-2.8.3.min.js"></script>
+	<script src="/libraries/angular/angular.js"></script>
+	<script src="/libraries/angular-route/angular-route.js"></script>
+	<script src="/libraries/angular-gettext/dist/angular-gettext.min.js"></script>
+	<script src="/libraries/jquery/dist/jquery.min.js"></script>
+	<script src="/libraries/skel/dist/skel.min.js"></script>
 
-      <script src="/assets/translations/id.js"></script>
-	  <script src="/measure/measure.js"></script>
-	  <script src="/services/gaugeService.js"></script>
-	  <script src="/app.js"></script>
-	  <script>
-	   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-	   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-	   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-	   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	<script src="/assets/js/jquery.scrollex.min.js"></script>
+	<script src="/assets/js/jquery.scrolly.min.js"></script>
+	<script src="/assets/js/util.js"></script>
+	<script src="/assets/js/main.js"></script>
 
-	   ga('create', 'UA-56251309-2', 'auto');
-	   ga('send', 'pageview');
-	  </script>
-	</body>
+	<script type="text/javascript" src="/libraries/ndt7.js"></script>
+	<script type="text/javascript" src="/libraries/re-tree.min.js"></script>
+	<script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
+	<script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+
+	<script src="/assets/translations/id.js"></script>
+	<script src="/measure/measure.js"></script>
+	<script src="/services/gaugeService.js"></script>
+	<script src="/app.js"></script>
+	<!-- Google tag (gtag.js) -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id=G-WV41BWS391"></script>
+	<script>
+		window.dataLayer = window.dataLayer || [];
+		function gtag() { dataLayer.push(arguments); }
+		gtag('js', new Date());
+
+		gtag('config', 'G-WV41BWS391');
+	</script>
+</body>
+
 </html>

--- a/app/nl/index.html
+++ b/app/nl/index.html
@@ -5,76 +5,79 @@
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
 <html ng-app="Measure">
-	<head>
-		<title>Speed Test by Measurement Lab</title>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<link rel="icon" href="/assets/images/mlab_logo_m.ico">
-		<link rel="stylesheet" href="/assets/css/main.css" />
-	</head>
-    <script>
-		const INTERFACE_LANGUAGE = 'nl';
-	</script>
-	<body>
 
-		<!-- Sidebar -->
-		<section id="sidebar">
-			<div class="inner">
-				<nav>
-					<ul>
-						<li><a href="#intro" class="active" translate>Measure</a></li>
-						<li><a href="#about" translate>About</a></li>
-						<li><a href="#contact" translate>Contact</a></li>
-					</ul>
-				</nav>
-			</div>
-		</section>
+<head>
+	<title>Speed Test by Measurement Lab</title>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<link rel="icon" href="/assets/images/mlab_logo_m.ico">
+	<link rel="stylesheet" href="/assets/css/main.css" />
+</head>
+<script>
+	const INTERFACE_LANGUAGE = 'nl';
+</script>
 
-		<!-- Wrapper -->
-		<div id="wrapper" ng-view></div>
+<body>
 
-		<!-- Footer -->
-		<footer id="footer" class="wrapper style1-alt">
-			<div class="inner">
-				<ul class="menu">
-					<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
-					<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
-					<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+	<!-- Sidebar -->
+	<section id="sidebar">
+		<div class="inner">
+			<nav>
+				<ul>
+					<li><a href="#intro" class="active" translate>Measure</a></li>
+					<li><a href="#about" translate>About</a></li>
+					<li><a href="#contact" translate>Contact</a></li>
 				</ul>
-			</div>
-		</footer>
+			</nav>
+		</div>
+	</section>
 
-		<!-- Scripts -->
+	<!-- Wrapper -->
+	<div id="wrapper" ng-view></div>
 
-		<script src="/libraries/html5-boilerplate/dist/js/vendor/modernizr-2.8.3.min.js"></script>
-		<script src="/libraries/angular/angular.js"></script>
-	  <script src="/libraries/angular-route/angular-route.js"></script>
-	  <script src="/libraries/angular-gettext/dist/angular-gettext.min.js"></script>
-	  <script src="/libraries/jquery/dist/jquery.min.js"></script>
-		<script src="/libraries/skel/dist/skel.min.js"></script>
+	<!-- Footer -->
+	<footer id="footer" class="wrapper style1-alt">
+		<div class="inner">
+			<ul class="menu">
+				<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
+				<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
+				<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+			</ul>
+		</div>
+	</footer>
 
-		<script src="/assets/js/jquery.scrollex.min.js"></script>
-		<script src="/assets/js/jquery.scrolly.min.js"></script>
-		<script src="/assets/js/util.js"></script>
-		<script src="/assets/js/main.js"></script>
+	<!-- Scripts -->
 
-	  <script type="text/javascript" src="/libraries/ndt7.js"></script>
-	  <script type="text/javascript" src="/libraries/re-tree.min.js"></script>
-	  <script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
-	  <script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+	<script src="/libraries/html5-boilerplate/dist/js/vendor/modernizr-2.8.3.min.js"></script>
+	<script src="/libraries/angular/angular.js"></script>
+	<script src="/libraries/angular-route/angular-route.js"></script>
+	<script src="/libraries/angular-gettext/dist/angular-gettext.min.js"></script>
+	<script src="/libraries/jquery/dist/jquery.min.js"></script>
+	<script src="/libraries/skel/dist/skel.min.js"></script>
 
-      <script src="/assets/translations/nl.js"></script>
-	  <script src="/measure/measure.js"></script>
-	  <script src="/services/gaugeService.js"></script>
-	  <script src="/app.js"></script>
-	  <script>
-	   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-	   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-	   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-	   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	<script src="/assets/js/jquery.scrollex.min.js"></script>
+	<script src="/assets/js/jquery.scrolly.min.js"></script>
+	<script src="/assets/js/util.js"></script>
+	<script src="/assets/js/main.js"></script>
 
-	   ga('create', 'UA-56251309-2', 'auto');
-	   ga('send', 'pageview');
-	  </script>
-	</body>
+	<script type="text/javascript" src="/libraries/ndt7.js"></script>
+	<script type="text/javascript" src="/libraries/re-tree.min.js"></script>
+	<script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
+	<script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+
+	<script src="/assets/translations/nl.js"></script>
+	<script src="/measure/measure.js"></script>
+	<script src="/services/gaugeService.js"></script>
+	<script src="/app.js"></script>
+	<!-- Google tag (gtag.js) -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id=G-WV41BWS391"></script>
+	<script>
+		window.dataLayer = window.dataLayer || [];
+		function gtag() { dataLayer.push(arguments); }
+		gtag('js', new Date());
+
+		gtag('config', 'G-WV41BWS391');
+	</script>
+</body>
+
 </html>

--- a/app/ru/index.html
+++ b/app/ru/index.html
@@ -5,76 +5,79 @@
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
 <html ng-app="Measure">
-	<head>
-		<title>Speed Test by Measurement Lab</title>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<link rel="icon" href="/assets/images/mlab_logo_m.ico">
-		<link rel="stylesheet" href="/assets/css/main.css" />
-	</head>
-    <script>
-		const INTERFACE_LANGUAGE = 'ru';
-	</script>
-	<body>
 
-		<!-- Sidebar -->
-		<section id="sidebar">
-			<div class="inner">
-				<nav>
-					<ul>
-						<li><a href="#intro" class="active" translate>Measure</a></li>
-						<li><a href="#about" translate>About</a></li>
-						<li><a href="#contact" translate>Contact</a></li>
-					</ul>
-				</nav>
-			</div>
-		</section>
+<head>
+	<title>Speed Test by Measurement Lab</title>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<link rel="icon" href="/assets/images/mlab_logo_m.ico">
+	<link rel="stylesheet" href="/assets/css/main.css" />
+</head>
+<script>
+	const INTERFACE_LANGUAGE = 'ru';
+</script>
 
-		<!-- Wrapper -->
-		<div id="wrapper" ng-view></div>
+<body>
 
-		<!-- Footer -->
-		<footer id="footer" class="wrapper style1-alt">
-			<div class="inner">
-				<ul class="menu">
-					<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
-					<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
-					<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+	<!-- Sidebar -->
+	<section id="sidebar">
+		<div class="inner">
+			<nav>
+				<ul>
+					<li><a href="#intro" class="active" translate>Measure</a></li>
+					<li><a href="#about" translate>About</a></li>
+					<li><a href="#contact" translate>Contact</a></li>
 				</ul>
-			</div>
-		</footer>
+			</nav>
+		</div>
+	</section>
 
-		<!-- Scripts -->
+	<!-- Wrapper -->
+	<div id="wrapper" ng-view></div>
 
-		<script src="/libraries/html5-boilerplate/dist/js/vendor/modernizr-2.8.3.min.js"></script>
-		<script src="/libraries/angular/angular.js"></script>
-	  <script src="/libraries/angular-route/angular-route.js"></script>
-	  <script src="/libraries/angular-gettext/dist/angular-gettext.min.js"></script>
-	  <script src="/libraries/jquery/dist/jquery.min.js"></script>
-		<script src="/libraries/skel/dist/skel.min.js"></script>
+	<!-- Footer -->
+	<footer id="footer" class="wrapper style1-alt">
+		<div class="inner">
+			<ul class="menu">
+				<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
+				<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
+				<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+			</ul>
+		</div>
+	</footer>
 
-		<script src="/assets/js/jquery.scrollex.min.js"></script>
-		<script src="/assets/js/jquery.scrolly.min.js"></script>
-		<script src="/assets/js/util.js"></script>
-		<script src="/assets/js/main.js"></script>
+	<!-- Scripts -->
 
-	  <script type="text/javascript" src="/libraries/ndt7.js"></script>
-	  <script type="text/javascript" src="/libraries/re-tree.min.js"></script>
-	  <script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
-	  <script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+	<script src="/libraries/html5-boilerplate/dist/js/vendor/modernizr-2.8.3.min.js"></script>
+	<script src="/libraries/angular/angular.js"></script>
+	<script src="/libraries/angular-route/angular-route.js"></script>
+	<script src="/libraries/angular-gettext/dist/angular-gettext.min.js"></script>
+	<script src="/libraries/jquery/dist/jquery.min.js"></script>
+	<script src="/libraries/skel/dist/skel.min.js"></script>
 
-      <script src="/assets/translations/ru.js"></script>
-	  <script src="/measure/measure.js"></script>
-	  <script src="/services/gaugeService.js"></script>
-	  <script src="/app.js"></script>
-	  <script>
-	   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-	   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-	   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-	   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	<script src="/assets/js/jquery.scrollex.min.js"></script>
+	<script src="/assets/js/jquery.scrolly.min.js"></script>
+	<script src="/assets/js/util.js"></script>
+	<script src="/assets/js/main.js"></script>
 
-	   ga('create', 'UA-56251309-2', 'auto');
-	   ga('send', 'pageview');
-	  </script>
-	</body>
+	<script type="text/javascript" src="/libraries/ndt7.js"></script>
+	<script type="text/javascript" src="/libraries/re-tree.min.js"></script>
+	<script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
+	<script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+
+	<script src="/assets/translations/ru.js"></script>
+	<script src="/measure/measure.js"></script>
+	<script src="/services/gaugeService.js"></script>
+	<script src="/app.js"></script>
+	<!-- Google tag (gtag.js) -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id=G-WV41BWS391"></script>
+	<script>
+		window.dataLayer = window.dataLayer || [];
+		function gtag() { dataLayer.push(arguments); }
+		gtag('js', new Date());
+
+		gtag('config', 'G-WV41BWS391');
+	</script>
+</body>
+
 </html>

--- a/app/zh/index.html
+++ b/app/zh/index.html
@@ -5,76 +5,79 @@
 	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 -->
 <html ng-app="Measure">
-	<head>
-		<title>Speed Test by Measurement Lab</title>
-		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<link rel="icon" href="/assets/images/mlab_logo_m.ico">
-		<link rel="stylesheet" href="/assets/css/main.css" />
-	</head>
-    <script>
-		const INTERFACE_LANGUAGE = 'zh';
-	</script>
-	<body>
 
-		<!-- Sidebar -->
-		<section id="sidebar">
-			<div class="inner">
-				<nav>
-					<ul>
-						<li><a href="#intro" class="active" translate>Measure</a></li>
-						<li><a href="#about" translate>About</a></li>
-						<li><a href="#contact" translate>Contact</a></li>
-					</ul>
-				</nav>
-			</div>
-		</section>
+<head>
+	<title>Speed Test by Measurement Lab</title>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<link rel="icon" href="/assets/images/mlab_logo_m.ico">
+	<link rel="stylesheet" href="/assets/css/main.css" />
+</head>
+<script>
+	const INTERFACE_LANGUAGE = 'zh';
+</script>
 
-		<!-- Wrapper -->
-		<div id="wrapper" ng-view></div>
+<body>
 
-		<!-- Footer -->
-		<footer id="footer" class="wrapper style1-alt">
-			<div class="inner">
-				<ul class="menu">
-					<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
-					<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
-					<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+	<!-- Sidebar -->
+	<section id="sidebar">
+		<div class="inner">
+			<nav>
+				<ul>
+					<li><a href="#intro" class="active" translate>Measure</a></li>
+					<li><a href="#about" translate>About</a></li>
+					<li><a href="#contact" translate>Contact</a></li>
 				</ul>
-			</div>
-		</footer>
+			</nav>
+		</div>
+	</section>
 
-		<!-- Scripts -->
+	<!-- Wrapper -->
+	<div id="wrapper" ng-view></div>
 
-		<script src="/libraries/html5-boilerplate/dist/js/vendor/modernizr-2.8.3.min.js"></script>
-		<script src="/libraries/angular/angular.js"></script>
-	  <script src="/libraries/angular-route/angular-route.js"></script>
-	  <script src="/libraries/angular-gettext/dist/angular-gettext.min.js"></script>
-	  <script src="/libraries/jquery/dist/jquery.min.js"></script>
-		<script src="/libraries/skel/dist/skel.min.js"></script>
+	<!-- Footer -->
+	<footer id="footer" class="wrapper style1-alt">
+		<div class="inner">
+			<ul class="menu">
+				<li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
+				<li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
+				<li><a href="http://www.measurementlab.net/privacy/" translate>Privacy Policy</a></li>
+			</ul>
+		</div>
+	</footer>
 
-		<script src="/assets/js/jquery.scrollex.min.js"></script>
-		<script src="/assets/js/jquery.scrolly.min.js"></script>
-		<script src="/assets/js/util.js"></script>
-		<script src="/assets/js/main.js"></script>
+	<!-- Scripts -->
 
-	  <script type="text/javascript" src="/libraries/ndt7.js"></script>
-	  <script type="text/javascript" src="/libraries/re-tree.min.js"></script>
-	  <script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
-	  <script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+	<script src="/libraries/html5-boilerplate/dist/js/vendor/modernizr-2.8.3.min.js"></script>
+	<script src="/libraries/angular/angular.js"></script>
+	<script src="/libraries/angular-route/angular-route.js"></script>
+	<script src="/libraries/angular-gettext/dist/angular-gettext.min.js"></script>
+	<script src="/libraries/jquery/dist/jquery.min.js"></script>
+	<script src="/libraries/skel/dist/skel.min.js"></script>
 
-      <script src="/assets/translations/zh.js"></script>
-	  <script src="/measure/measure.js"></script>
-	  <script src="/services/gaugeService.js"></script>
-	  <script src="/app.js"></script>
-	  <script>
-	   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-	   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-	   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-	   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	<script src="/assets/js/jquery.scrollex.min.js"></script>
+	<script src="/assets/js/jquery.scrolly.min.js"></script>
+	<script src="/assets/js/util.js"></script>
+	<script src="/assets/js/main.js"></script>
 
-	   ga('create', 'UA-56251309-2', 'auto');
-	   ga('send', 'pageview');
-	  </script>
-	</body>
+	<script type="text/javascript" src="/libraries/ndt7.js"></script>
+	<script type="text/javascript" src="/libraries/re-tree.min.js"></script>
+	<script type="text/javascript" src="/libraries/ua-device-detector.min.js"></script>
+	<script type="text/javascript" src="/libraries/ng-device-detector.min.js"></script>
+
+	<script src="/assets/translations/zh.js"></script>
+	<script src="/measure/measure.js"></script>
+	<script src="/services/gaugeService.js"></script>
+	<script src="/app.js"></script>
+	<!-- Google tag (gtag.js) -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id=G-WV41BWS391"></script>
+	<script>
+		window.dataLayer = window.dataLayer || [];
+		function gtag() { dataLayer.push(arguments); }
+		gtag('js', new Date());
+
+		gtag('config', 'G-WV41BWS391');
+	</script>
+</body>
+
 </html>


### PR DESCRIPTION
## Summary
Fixes the dead Universal Analytics tracking reported in #<ISSUE_NUMBER> across all 11 language-specific subpages.

## Problem
All 11 language subpages were still running the old `analytics.js` Universal Analytics snippet with a `UA-56251309-2` tracking ID. Google sunset UA on July 1, 2023, so these pages have been recording zero analytics data since then.

## Changes
Removed the old UA snippet from all 11 language files

Replaced with the modern GA4 snippet matching `app/index.html`:
```html
<!-- Google tag (gtag.js) -->
<script async src="https://www.googletagmanager.com/gtag/js?id=G-WV41BWS391"></script>
<script>
  window.dataLayer = window.dataLayer || [];
  function gtag(){dataLayer.push(arguments);}
  gtag('js', new Date());
  gtag('config', 'G-WV41BWS391');
</script>
```

## Type of Change
- [x] Bug fix

## Testing
- [x] Opened each language subpage in browser
- [x] Verified in browser DevTools Network tab that `analytics.js` is no longer loaded
- [x] Verified `gtag.js` is loaded correctly
- [x] Confirmed events appearing in GA4 dashboard DebugView

## Related Issue
Closes #127 