### PR TITLE
fix: add error handling for speed test failures

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -111,22 +111,29 @@ const SpeedTest = {
     // Generate a random UUID
     const sessionID = crypto.randomUUID();
 
-    // Randomly choose which test to start first
-    if (Math.random() < 0.5) {
-      await this.runNdt7(sessionID);
-      await this.runMSAK(sessionID);
-    } else {
-      await this.runMSAK(sessionID);
-      await this.runNdt7(sessionID);
+    try {
+      // Randomly choose which test to start first
+      if (Math.random() < 0.5) {
+        await this.runNdt7(sessionID);
+        await this.runMSAK(sessionID);
+      } else {
+        await this.runMSAK(sessionID);
+        await this.runNdt7(sessionID);
+      }
+
+      this.runPT(sessionID);
+
+      this.els.currentPhase.textContent = i18n.t('Complete');
+      this.els.currentSpeed.textContent = '';
+      this.measurementComplete = true;
+    } catch (err) {
+      console.error('Speed test failed:', err);
+      this.els.currentPhase.textContent = i18n.t('Error');
+      this.els.currentSpeed.textContent = i18n.t('Test failed. Please try again.');
+    } finally {
+      this.testRunning = false;
+      this.updateUI();
     }
-
-    this.runPT(sessionID);
-
-    this.els.currentPhase.textContent = i18n.t('Complete');
-    this.els.currentSpeed.textContent = '';
-    this.measurementComplete = true;
-    this.testRunning = false;
-    this.updateUI();
   },
 
   /**


### PR DESCRIPTION
The startTest() method in app.js awaits runNdt7() and runMSAK() without any error handling. If either test fails — due to a network error, server timeout, or any thrown exception — the UI remains stuck in the "Testing" state with no way for the user to retry. This PR wraps the test execution in a try/catch/finally block: on success, results display as before; on failure, the user sees a "Test failed. Please try again." message; and in both cases, the finally block resets testRunning and updates the UI so the start button becomes clickable again.

