### PR TITLE
fix: address review comments from PR #83

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -11,7 +11,7 @@ jobs:
     if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '20'

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -66,7 +66,8 @@ function build() {
 
   // Convert .po translations to JSON
   console.log('Converting translations...');
-  require('./po-to-json');
+  const convertTranslations = require('./po-to-json');
+  convertTranslations(path.join(DIST, 'translations'));
 
   // Copy M-Lab libraries from node_modules
   console.log('Copying M-Lab libraries...');

--- a/scripts/po-to-json.js
+++ b/scripts/po-to-json.js
@@ -9,7 +9,7 @@ const path = require('path');
 const gettextParser = require('gettext-parser');
 
 const LANGUAGES_DIR = path.join(__dirname, '..', 'translations', 'languages');
-const OUTPUT_DIR = process.argv[2] || path.join(__dirname, '..', 'dist', 'translations');
+const DEFAULT_OUTPUT_DIR = path.join(__dirname, '..', 'dist', 'translations');
 
 // Language code mapping (e.g., de_DE.po -> de.json)
 const LANG_MAP = {
@@ -33,10 +33,12 @@ function convertPoToJson(poFilePath) {
   return translations;
 }
 
-function main() {
+function convert(outputDir) {
+  const outDir = outputDir || DEFAULT_OUTPUT_DIR;
+
   // Ensure output directory exists
-  if (!fs.existsSync(OUTPUT_DIR)) {
-    fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+  if (!fs.existsSync(outDir)) {
+    fs.mkdirSync(outDir, { recursive: true });
   }
 
   const poFiles = fs.readdirSync(LANGUAGES_DIR).filter(f => f.endsWith('.po'));
@@ -53,7 +55,7 @@ function main() {
     }
 
     const translations = convertPoToJson(poPath);
-    const jsonPath = path.join(OUTPUT_DIR, `${langCode}.json`);
+    const jsonPath = path.join(outDir, `${langCode}.json`);
 
     fs.writeFileSync(jsonPath, JSON.stringify(translations, null, 2));
     console.log(`  ${poFile} -> ${langCode}.json (${Object.keys(translations).length} strings)`);
@@ -62,4 +64,9 @@ function main() {
   console.log('Done!');
 }
 
-main();
+module.exports = convert;
+
+// Allow standalone usage: node po-to-json.js [outputDir]
+if (require.main === module) {
+  convert(process.argv[2]);
+}

--- a/src/index.html
+++ b/src/index.html
@@ -19,9 +19,9 @@
       <div class="inner">
         <nav>
           <ul>
-            <li><a href="#intro" class="active" data-i18n="Measure">Measure</a></li>
-            <li><a href="#about" data-i18n="About">About</a></li>
-            <li><a href="#contact" data-i18n="Contact">Contact</a></li>
+            <li><a href="#intro" class="active" data-i18n>Measure</a></li>
+            <li><a href="#about" data-i18n>About</a></li>
+            <li><a href="#contact" data-i18n>Contact</a></li>
           </ul>
         </nav>
       </div>
@@ -34,25 +34,25 @@
       <section id="intro" class="wrapper style1 fullscreen">
         <div class="features">
           <section>
-            <h1 data-i18n="Test Your Speed">Test Your Speed</h1>
+            <h1 data-i18n>Test Your Speed</h1>
             <p class="startIntroLabel">
-              <span data-i18n="M-Lab's Speed Test provides advanced diagnostics of the performance of your broadband connection through quick measurements.">M-Lab's Speed Test provides advanced diagnostics of the performance of your broadband connection through quick measurements.</span><br />
+              <span data-i18n>M-Lab's Speed Test provides advanced diagnostics of the performance of your broadband connection through quick measurements.</span><br />
             </p>
             <p>
               <input type="checkbox" id="privacyConsent" name="privacyConsent">
-              <label for="privacyConsent" style="font-size: smaller;" data-i18n="I agree to the <a href=&quot;http://www.measurementlab.net/privacy/&quot;>data policy</a>, which includes retention and publication of IP addresses." data-i18n-html>I agree to the <a href="http://www.measurementlab.net/privacy/">data policy</a>, which includes retention and publication of IP addresses.</label>
+              <label for="privacyConsent" style="font-size: smaller;" data-i18n data-i18n-html>I agree to the <a href="http://www.measurementlab.net/privacy/">data policy</a>, which includes retention and publication of IP addresses.</label>
             </p>
             <p>
               <div class="row">
                 <div class="col-6">
                   <a id="startButton" class="button special startButton big disabled">
-                    <span class="btn-begin"><span data-i18n="Begin">Begin</span> <i class="fa fa-play" aria-hidden="true"></i></span>
-                    <span class="btn-again" style="display:none;"><span data-i18n="Again">Again</span> <i class="fa fa-repeat" aria-hidden="true"></i></span>
-                    <span class="btn-testing" style="display:none;"><span data-i18n="Testing">Testing</span> <i class="fa fa-circle-o-notch fa-spin" aria-hidden="true"></i></span>
+                    <span class="btn-begin"><span data-i18n>Begin</span> <i class="fa fa-play" aria-hidden="true"></i></span>
+                    <span class="btn-again" style="display:none;"><span data-i18n>Again</span> <i class="fa fa-repeat" aria-hidden="true"></i></span>
+                    <span class="btn-testing" style="display:none;"><span data-i18n>Testing</span> <i class="fa fa-circle-o-notch fa-spin" aria-hidden="true"></i></span>
                   </a>
                 </div>
                 <div class="col-6">
-                  <span id="privacyMessage" data-i18n="Please agree to the data policy prior to the test." class="privacyConsentMessage">Please agree to the data policy prior to the test.</span>
+                  <span id="privacyMessage" data-i18n class="privacyConsentMessage">Please agree to the data policy prior to the test.</span>
                 </div>
               </div>
             </p>
@@ -60,7 +60,7 @@
               measurement protocols. This means
               results may take a little longer to appear than usual. Thank you for your help.
             </small><br /><br />
-            <small data-i18n="For more on M-Lab's data collection and measurement, including the disclosure of IP addresses, see our <a href=&quot;http://www.measurementlab.net/privacy/&quot;>Privacy Policy</a>." data-i18n-html>For more on M-Lab's data collection and measurement, including the disclosure of IP addresses, see our <a href="http://www.measurementlab.net/privacy/">Privacy Policy</a>.</small>
+            <small data-i18n data-i18n-html>For more on M-Lab's data collection and measurement, including the disclosure of IP addresses, see our <a href="http://www.measurementlab.net/privacy/">Privacy Policy</a>.</small>
           </section>
           <section id="measurementSpace">
             <div id="progressSection">
@@ -74,7 +74,7 @@
               </div>
             </div>
             <div id="resultsSection" style="display: none;">
-              <h1 data-i18n="Results">Results</h1>
+              <h1 data-i18n>Results</h1>
               <table class="alt">
                 <tbody>
                   <tr>
@@ -85,31 +85,31 @@
                   </tr>
                   <tr>
                     <td><i class="fa fa-server" aria-hidden="true"></i></td>
-                    <td data-i18n="Test Server">Test Server</td>
+                    <td data-i18n>Test Server</td>
                     <td><strong id="ndtLocation"></strong></td>
                     <td><strong id="msakLocation"></strong></td>
                   </tr>
                   <tr>
                     <td><i class="fa fa-download" aria-hidden="true"></i></td>
-                    <td data-i18n="Download">Download</td>
+                    <td data-i18n>Download</td>
                     <td><strong id="s2cRate"></strong></td>
                     <td><strong id="msakDownload"></strong></td>
                   </tr>
                   <tr>
                     <td><i class="fa fa-upload" aria-hidden="true"></i></td>
-                    <td data-i18n="Upload">Upload</td>
+                    <td data-i18n>Upload</td>
                     <td><strong id="c2sRate"></strong></td>
                     <td><strong id="msakUpload"></strong></td>
                   </tr>
                   <tr>
                     <td><i class="fa fa-hourglass-start" aria-hidden="true"></i></td>
-                    <td data-i18n="Latency">Latency</td>
+                    <td data-i18n>Latency</td>
                     <td><strong id="latency"></strong></td>
                     <td><strong id="msakLatency"></strong></td>
                   </tr>
                   <tr>
                     <td><i class="fa fa-signal" aria-hidden="true"></i></td>
-                    <td data-i18n="Retransmission">Retransmission</td>
+                    <td data-i18n>Retransmission</td>
                     <td><strong id="loss"></strong></td>
                     <td><strong id="msakLoss"></strong></td>
                   </tr>
@@ -123,32 +123,32 @@
       <!-- About -->
       <section id="about" class="wrapper style3">
         <div class="inner">
-          <h2 data-i18n="About">About</h2>
-          <p data-i18n="Measurement Lab (M-Lab) provides the largest collection of open Internet performance data on the planet. As a consortium of research, industry, and public-interest partners, M-Lab is dedicated to providing an ecosystem for the open, verifiable measurement of global network performance.">Measurement Lab (M-Lab) provides the largest collection of open Internet performance data on the planet. As a consortium of research, industry, and public-interest partners, M-Lab is dedicated to providing an ecosystem for the open, verifiable measurement of global network performance.</p>
+          <h2 data-i18n>About</h2>
+          <p data-i18n>Measurement Lab (M-Lab) provides the largest collection of open Internet performance data on the planet. As a consortium of research, industry, and public-interest partners, M-Lab is dedicated to providing an ecosystem for the open, verifiable measurement of global network performance.</p>
           <div class="features">
             <section>
               <span class="icon major fa-code"></span>
-              <h3 data-i18n="Open Source">Open Source</h3>
-              <p data-i18n="Measurement tools are openly licensed and operated, allowing third parties to develop their own client-side measurement software and audit the source.">Measurement tools are openly licensed and operated, allowing third parties to develop their own client-side measurement software and audit the source.</p>
+              <h3 data-i18n>Open Source</h3>
+              <p data-i18n>Measurement tools are openly licensed and operated, allowing third parties to develop their own client-side measurement software and audit the source.</p>
             </section>
             <section>
               <span class="icon major fa-users"></span>
-              <h3 data-i18n="Public Data">Public Data</h3>
-              <p data-i18n="Data collected is made available to the public, allowing researchers and anyone else to build on a common pool of network measurement information.">Data collected is made available to the public, allowing researchers and anyone else to build on a common pool of network measurement information.</p>
+              <h3 data-i18n>Public Data</h3>
+              <p data-i18n>Data collected is made available to the public, allowing researchers and anyone else to build on a common pool of network measurement information.</p>
             </section>
             <section>
               <span class="icon major fa-globe"></span>
-              <h3 data-i18n="Global">Global</h3>
-              <p data-i18n="Distributed infrastructure and large user base provides an open, verifiable measurement platform for global network performance.">Distributed infrastructure and large user base provides an open, verifiable measurement platform for global network performance.</p>
+              <h3 data-i18n>Global</h3>
+              <p data-i18n>Distributed infrastructure and large user base provides an open, verifiable measurement platform for global network performance.</p>
             </section>
             <section>
               <span class="icon major fa-institution"></span>
-              <h3 data-i18n="Trusted">Trusted</h3>
-              <p data-i18n="Used by public organization, academic researchers, regulators and companies around the world to understand the health of the Internet.">Used by public organization, academic researchers, regulators and companies around the world to understand the health of the Internet.</p>
+              <h3 data-i18n>Trusted</h3>
+              <p data-i18n>Used by public organization, academic researchers, regulators and companies around the world to understand the health of the Internet.</p>
             </section>
           </div>
           <ul class="actions">
-            <li><a href="http://measurementlab.net" class="button" data-i18n="Learn more">Learn more</a></li>
+            <li><a href="http://measurementlab.net" class="button" data-i18n>Learn more</a></li>
           </ul>
         </div>
       </section>
@@ -156,30 +156,30 @@
       <!-- Contact -->
       <section id="contact" class="wrapper style1">
         <div class="inner">
-          <h2 data-i18n="Contact">Contact</h2>
+          <h2 data-i18n>Contact</h2>
           <ul class="alt">
-            <li data-i18n="Questions or comments about M-Lab and its tools?">Questions or comments about M-Lab and its tools?</li>
-            <li data-i18n="Want to participate in M-Lab?">Want to participate in M-Lab?</li>
-            <li data-i18n="Need to report an issue or bug?">Need to report an issue or bug?</li>
-            <li data-i18n="Please contact us.">Please contact us.</li>
+            <li data-i18n>Questions or comments about M-Lab and its tools?</li>
+            <li data-i18n>Want to participate in M-Lab?</li>
+            <li data-i18n>Need to report an issue or bug?</li>
+            <li data-i18n>Please contact us.</li>
           </ul>
           <div class="">
             <section>
               <ul class="contact">
                 <li>
-                  <h3 data-i18n="Email">Email</h3>
+                  <h3 data-i18n>Email</h3>
                   <a href="mailto:support@measurementlab.net">support@measurementlab.net</a>
                 </li>
                 <li>
-                  <h3 data-i18n="Discussion and Notification Group">Discussion and Notification Group</h3>
-                  <a href="https://groups.google.com/a/measurementlab.net/forum/#!forum/discuss" target="_blank" data-i18n="Join Group">Join Group</a>
+                  <h3 data-i18n>Discussion and Notification Group</h3>
+                  <a href="https://groups.google.com/a/measurementlab.net/forum/#!forum/discuss" target="_blank" data-i18n>Join Group</a>
                   <i class="fa fa-link" aria-hidden="true"></i>
                 </li>
                 <li>
-                  <h3 data-i18n="Social">Social</h3>
+                  <h3 data-i18n>Social</h3>
                   <ul class="icons">
-                    <li><a href="https://twitter.com/MeasurementLab" class="fa-twitter" target="_blank"><span class="label" data-i18n="Twitter">Twitter</span></a></li>
-                    <li><a href="https://github.com/m-lab" class="fa-github" target="_blank"><span class="label" data-i18n="GitHub">GitHub</span></a></li>
+                    <li><a href="https://twitter.com/MeasurementLab" class="fa-twitter" target="_blank"><span class="label" data-i18n>Twitter</span></a></li>
+                    <li><a href="https://github.com/m-lab" class="fa-github" target="_blank"><span class="label" data-i18n>GitHub</span></a></li>
                   </ul>
                 </li>
               </ul>
@@ -196,7 +196,7 @@
         <ul class="menu">
           <li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
           <li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
-          <li><a href="http://www.measurementlab.net/privacy/" data-i18n="Privacy Policy">Privacy Policy</a></li>
+          <li><a href="http://www.measurementlab.net/privacy/" data-i18n>Privacy Policy</a></li>
         </ul>
       </div>
     </footer>

--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -58,9 +58,17 @@ const i18n = {
 
   translatePage() {
     document.querySelectorAll('[data-i18n]').forEach(el => {
-      const key = el.dataset.i18n;
+      // Use explicit key if provided, otherwise derive from element content.
+      // This avoids fragile duplication of text in both the attribute and content.
+      let key = el.dataset.i18n;
+      if (!key) {
+        key = (el.dataset.i18nHtml !== undefined)
+          ? el.innerHTML.trim()
+          : el.textContent.trim();
+        // Store derived key for subsequent calls (e.g. re-translation)
+        el.dataset.i18n = key;
+      }
       if (key) {
-        // Check if element has HTML content that needs translation
         if (el.dataset.i18nHtml !== undefined) {
           el.innerHTML = this.t(key);
         } else {


### PR DESCRIPTION
This PR addresses three review comments from #83:

1. Side-effect import in build.js (R69): scripts/po-to-json.js previously ran the conversion on require(). It now exports a convert(outputDir) function that build.js calls explicitly. The script still works standalone via node po-to-json.js [outputDir].

2. Outdated checkout action (R14): Updated actions/checkout@v4 → @v6 in firebase-hosting-pull-request.yml, matching firebase-hosting-merge.yml.

3. Fragile data-i18n duplication (R39): The data-i18n="English text" attribute duplicated the element's text content. Updated i18n.js to derive the translation key from the element's textContent (or innerHTML for data-i18n-html elements) when the attribute value is empty. Removed all duplicate values from index.html, leaving data-i18n as a marker attribute.