### PR TITLE
ci: add path filtering to skip builds on docs/translation changes

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -6,6 +6,9 @@ name: Deploy to Firebase Hosting on merge
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'translations/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -2,7 +2,11 @@
 # https://github.com/firebase/firebase-tools
 
 name: Deploy to Firebase Hosting on PR
-'on': pull_request
+'on':
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'translations/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
## Summary

Skip CI builds when only non-code files are changed, reducing unnecessary GitHub Actions usage.

## Changes

Added `paths-ignore` to both workflow files:
- `firebase-hosting-merge.yml` — skips build+deploy on push to `main`
- `firebase-hosting-pull-request.yml` — skips preview deploy on PRs

**Ignored paths:**
- `**.md` — README and documentation files
- `translations/**` — `.po`/`.pot` translation files

## Why

Currently, pushing a README typo fix or updating a translation triggers a full `npm ci` + `gulp copy_libs` + Firebase deploy — even though nothing in the app changed. With path filtering:

- ✅ Code changes → CI runs as normal
- ✅ Docs/translation-only changes → CI skipped, no minutes wasted

## Testing

No functional changes to application code or tests. Workflow syntax is valid YAML.