### PR TITLE
ci: add actionlint to validate GitHub Actions workflow syntax

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,24 @@
+name: Lint GitHub Actions workflows
+
+'on':
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**.yml'
+  pull_request:
+    paths:
+      - '.github/workflows/**.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint GitHub Actions workflow files
+        uses: rhysd/actionlint@v1.7.7


### PR DESCRIPTION
## Summary

Adds a dedicated `lint.yml` workflow that runs [actionlint](https://github.com/rhysd/actionlint) on all `.github/workflows/` YAML files to catch mistakes in CI configuration before they reach `main`.

## What actionlint catches

- Invalid `${{ }}` expressions and contexts
- Wrong action input names or missing required inputs
- Incorrect event/trigger syntax
- Shell script errors inside `run:` steps (via shellcheck integration)
- Referencing undefined job outputs or step IDs

## Changes

- Added `.github/workflows/lint.yml`

## Design decisions

- **Pinned to `rhysd/actionlint@v1.7.7`** — not `@v1`, avoids floating tag
- **Path-filtered to `.github/workflows/**.yml`** — only runs when workflow files actually change, saves CI minutes
- **Concurrency group** — cancels redundant runs on rapid pushes
- **`timeout-minutes: 5`** — lint should complete in seconds, 5 min is a safe ceiling

## Why this stays relevant after PR #83

actionlint only checks `.github/workflows/` — it is completely independent of app code, framework, or dependencies. It will continue to be useful regardless of what the application stack looks like.