### PR TITLE
fix: harden measurement flow and guard gauge initialization

### DIFF
--- a/app/services/gaugeService.js
+++ b/app/services/gaugeService.js
@@ -2,6 +2,15 @@ angular.module('Measure.GaugeService', [])
 
 .factory('ProgressGauge', function() {
   var aProgress = document.getElementById('activeProgress');
+  if (!aProgress) {
+    console.warn('ProgressGauge: missing #activeProgress element');
+    return {
+      element: null,
+      reset: function() {},
+      progress: function() {},
+      create: function() {}
+    };
+  }
   var barCTX = aProgress.getContext("2d");
 
   function setInactive() {


### PR DESCRIPTION
- Prevent crashes when `#activeProgress` is missing by safely no-oping the gauge service.
- Ensure the start button resets even if a test fails by wrapping execution in try/catch/finally.
- Use $applyAsync and defensive metric calculations to avoid digest errors and NaN/Infinity in results.