### PR TITLE
ci: add npm ecosystem to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

Extends the existing Dependabot config to also track npm dependencies, so packages like `@m-lab/ndt7`, `@m-lab/msak`, and devDependencies receive automated update PRs when new versions are published.



## Why

Previously Dependabot only tracked GitHub Actions versions (e.g., `actions/checkout`). npm packages were completely unmonitored — security patches and new releases for `@m-lab/ndt7`, `@m-lab/msak` etc. had to be caught manually.

With this change, Dependabot will raise weekly PRs for outdated npm packages, keeping dependencies up to date automatically.

