### PR TITLE
Smooth progress ring: lerp on increase, snap on decrease

### DIFF
--- a/app/services/gaugeService.js
+++ b/app/services/gaugeService.js
@@ -3,13 +3,27 @@ angular.module('Measure.GaugeService', [])
 .factory('ProgressGauge', function() {
   var aProgress = document.getElementById('activeProgress');
   var barCTX = aProgress.getContext("2d");
+  var targetProgress = 0, displayProgress = 0, animationId = null;
+
+  function tick() {
+    displayProgress += (targetProgress - displayProgress) * 0.14;
+    if (Math.abs(displayProgress - targetProgress) < 0.003) { displayProgress = targetProgress; animationId = null; }
+    drawProgress(displayProgress);
+    if (animationId !== null) animationId = requestAnimationFrame(tick);
+  }
 
   function setInactive() {
+    if (animationId !== null) cancelAnimationFrame(animationId);
+    animationId = null;
+    targetProgress = 1; displayProgress = 1;
     drawProgress(1);
     aProgress.classList.remove('activeGauge')
     aProgress.classList.add('inactiveGauge')
   }
   function resetProgress() {
+    if (animationId !== null) cancelAnimationFrame(animationId);
+    animationId = null;
+    targetProgress = 0; displayProgress = 0;
     drawProgress(0);
     aProgress.classList.remove('inactiveGauge')
     aProgress.classList.add('activeGauge')
@@ -43,10 +57,22 @@ angular.module('Measure.GaugeService', [])
     setInactive();
   }
 
+  function progress(target) {
+    targetProgress = Math.max(0, Math.min(1, target));
+    if (targetProgress < displayProgress) {
+      if (animationId !== null) cancelAnimationFrame(animationId);
+      animationId = null;
+      displayProgress = targetProgress;
+      drawProgress(displayProgress);
+    } else if (animationId === null) {
+      animationId = requestAnimationFrame(tick);
+    }
+  }
+
   return {
     "element": aProgress,
     'reset': resetProgress,
-    'progress': drawProgress,
+    'progress': progress,
     'create': createProgress
   };
 


### PR DESCRIPTION
# Proposed Changes

Fixes #154 

### Smooth the speed-test progress ring
The circular progress ring was jumping on every update during the test. It now animates smoothly when the value increases and snaps to the new value when it decreases (e.g. between download and upload), so behaviour matches main branch and the ring no longer jitters. Changes are limited to the gauge service; no template or controller updates.

#### Before :

https://github.com/user-attachments/assets/bb1baea6-56fa-4abf-8a8b-efe66fc0a96f

#### After :


https://github.com/user-attachments/assets/85a36c7f-1712-48ae-aef3-6d281f786d2d




