### PR TITLE
fix: prevent division-by-zero in NDT loss calculation

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -200,9 +200,15 @@ const SpeedTest = {
             data.LastClientMeasurement.MeanClientMbps.toFixed(2) + ' Mb/s';
           self.measurementResult.latency =
             (data.LastServerMeasurement.TCPInfo.MinRTT / 1000).toFixed(0) + ' ms';
-          self.measurementResult.loss =
-            (data.LastServerMeasurement.TCPInfo.BytesRetrans /
-              data.LastServerMeasurement.TCPInfo.BytesSent * 100).toFixed(2) + '%';
+            const bytesSent = data.LastServerMeasurement.TCPInfo.BytesSent;
+            const bytesRetrans = data.LastServerMeasurement.TCPInfo.BytesRetrans;
+            
+            if (bytesSent > 0) {
+              self.measurementResult.loss = ((bytesRetrans / bytesSent) * 100).toFixed(2) + '%';
+            } else {
+              // no data sent, avoid division by zero
+              self.measurementResult.loss = 'N/A';
+            }
           self.els.s2cRate.textContent = self.measurementResult.s2cRate;
           self.els.latency.textContent = self.measurementResult.latency;
           self.els.loss.textContent = self.measurementResult.loss;


### PR DESCRIPTION
### Summary

This PR fixes a correctness error in the NDT7 loss percentage calculation.

When TCPInfo.BytesSent is 0, the existing code performed:

    BytesRetrans / BytesSent * 100

This results in Infinity or NaN depending on the browser.  
Calling `.toFixed(2)` on NaN/Infinity also causes incorrect UI output.

### Fix

- Added a guard for `BytesSent === 0`
- Shows `"N/A"` when no bytes were sent
- Prevents division-by-zero and invalid loss display

### Why this matters

Certain edge cases in the NDT7 protocol (early termination, handshake failure,
or server-side abort) produce 0-byte measurements.

Previously this resulted in:

- NaN%  
- Infinity%  
- Or broken UI output

This PR ensures safe, predictable behavior without affecting the core measurement logic.