### PR TITLE
fix: rename inject variable to avoid shadowing gulp-inject plugin

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,10 +1,10 @@
 var gulp = require('gulp');
-var inject = require('gulp-inject');
+var gulpInject = require('gulp-inject'); 
 var gettext = require('gulp-angular-gettext');
 
 function inject(cb) {
   gulp.src('www/index.html')
-  .pipe(inject(gulp.src('www/translations/scripts/*.js', {read: false}), {relative: true, name: 'translations'}))
+  .pipe(gulpInject(gulp.src('www/translations/scripts/*.js', {read: false}), {relative: true, name: 'translations'}))
   .pipe(gulp.dest('www'));
 
   cb();


### PR DESCRIPTION
fixes issue : #119
The gulp-inject module was imported as 'inject' which was shadowed 
by the Gulp task function also named 'inject' This caused infinite 
recursion when running 'gulp inject':
RangeError: Maximum call stack size exceeded

#119 Fix
Renamed import variable from `inject` to `gulpInject` to avoid the 
naming conflict