### PR TITLE
Fixes#123-dead code cb after return

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,7 @@ function translations(cb) {
   return gulp.src('translations/languages/*.po')
   .pipe(gettext.compile())
   .pipe(gulp.dest('app/assets/translations/'));
-  cb();
+
 };
 
 function pot(cb) {
@@ -28,7 +28,7 @@ function pot(cb) {
   }))
   .pipe(gulp.dest('translations/source'));
 
-  cb();
+  
 };
 
 // Copy dependencies to ./public/libs/


### PR DESCRIPTION
Fixes : #123 
Problem
In both translations and pot task functions, cb() was placed 
after a return statement making it dead code that can never be 
executed.

Fix
Since both functions return a stream, Gulp 4 handles task completion 
automatically. Removed the unnecessary 'cb' parameter and dead cb() 
calls from both functions.

 Changes
- gulpfile.js: removed 'cb' parameter from translations function
- gulpfile.js: removed 'cb' parameter and dead 'cb()' from pot function