### PR TITLE
Disable consent checkbox while test is running

### DIFF
--- a/app/measure/measure.html
+++ b/app/measure/measure.html
@@ -8,7 +8,7 @@
           through quick measurements.</span><br />
       </p>
       <p>
-        <input type="checkbox" id="demo-human" name="demo-human" ng-model="privacyConsent">
+        <input type="checkbox" id="demo-human" name="demo-human" ng-model="privacyConsent" ng-disabled="testRunning">
         <label for="demo-human" translate style="font-size: smaller;">I agree to the <a
             href="http://www.measurementlab.net/privacy/">data policy</a>, which includes retention and publication of
           IP addresses.</label>

--- a/app/measure/measure.js
+++ b/app/measure/measure.js
@@ -7,6 +7,7 @@ angular.module('Measure.Measure', ['ngRoute'])
     var testRunning = false;
 
     $scope.measurementComplete = false;
+    $scope.testRunning = false;
 
     ProgressGauge.create();
 
@@ -31,6 +32,7 @@ angular.module('Measure.Measure', ['ngRoute'])
         return;
       }
       testRunning = true;
+      $scope.testRunning = true;
 
       if ($(window).width() < 981) {
         $('html, body').animate({
@@ -63,6 +65,7 @@ angular.module('Measure.Measure', ['ngRoute'])
         $scope.startButtonClass = '';
       });
       testRunning = false;
+      $scope.testRunning = false;
     }
 
     // Determine the M-Lab project based on a placeholder that is substituted


### PR DESCRIPTION
Fixes: #159

Prevent users from modifying privacy consent during an active test.

The consent checkbox is disabled when the test starts and re-enabled upon completion, ensuring the UI state remains consistent with test execution.