### PR TITLE
fix: route ndt7 tests to production instead of staging

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -134,7 +134,7 @@ const SpeedTest = {
    */
   mlabProject() {
     const placeholder = 'MLAB_PROJECT_PLACEHOLDER';
-    return placeholder === 'MLAB_PROJECT_PLACEHOLDER' ? 'mlab-staging' : placeholder;
+    return placeholder.includes('PLACEHOLDER') ? 'mlab-staging' : placeholder;
   },
 
   /**


### PR DESCRIPTION
## Summary

- Fix `mlabProject()` so the sed placeholder substitution in CI actually works
- The strict equality check `placeholder === 'MLAB_PROJECT_PLACEHOLDER'` was replaced by sed into `'mlab-oti' === 'mlab-oti'` which is always true, causing the function to always return `'mlab-staging'`
- Changed to `placeholder.includes('PLACEHOLDER')` which correctly evaluates to `false` after substitution

## Impact

Since the 2026-02-03 release, **all ndt7 tests from the website have been routed to staging infrastructure**. This caused:
- ndt7 test data in production BigQuery dropped from ~2,000/day to ~15/day
- MSAK tests were unaffected (they don't use this code path)
- Tests appeared to work correctly for users — results displayed fine in the browser — but data landed in the staging project instead of production