### PR TITLE
changed the color of the footer text to white

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1140,7 +1140,7 @@ table.alt tfoot {
 
 #footer > .inner .menu {
   font-size: 0.8em;
-  color: rgba(255, 255, 255, 0.15);
+  color:#ffffff;
 }
 
 /* ============================================


### PR DESCRIPTION
Current Behaviour : the text on the footer was not very clear because the the grey text had low contrast against the dark purple background

<img width="1510" height="197" alt="image" src="https://github.com/user-attachments/assets/542c8224-aa6e-4e3b-a5a9-ecca14fd6d19" />

After change : changed the footer text color to white for better visibility again the dark color background.

<img width="1514" height="186" alt="image" src="https://github.com/user-attachments/assets/b9c0bb59-f0fa-4f05-bccc-4af37309218c" />

fixes #138