### PR TITLE
style: update footer menu color for better visibility

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1140,7 +1140,7 @@ table.alt tfoot {
 
 #footer > .inner .menu {
   font-size: 0.8em;
-  color: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.45);
 }
 
 /* ============================================


### PR DESCRIPTION

Improves footer menu visibility by updating the colour to meet WCAG contrast requirements against the background. This ensures better readability and accessibility across themes.

**Fixes:** #138
Before:
<img width="956" height="140" alt="image" src="https://github.com/user-attachments/assets/52176f61-fc16-4546-acdd-75855a583e00" />

After :
<img width="1898" height="467" alt="image" src="https://github.com/user-attachments/assets/bd047bc7-4fac-410b-bc48-0a2505bda4c7" />
