### PR TITLE
fix: use https links on homepage and i18n strings (#184)

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -40,7 +40,7 @@
             </p>
             <p>
               <input type="checkbox" id="privacyConsent" name="privacyConsent">
-              <label for="privacyConsent" style="font-size: smaller;" data-i18n data-i18n-html>I agree to the <a href="http://www.measurementlab.net/privacy/">data policy</a>, which includes retention and publication of IP addresses.</label>
+              <label for="privacyConsent" style="font-size: smaller;" data-i18n data-i18n-html>I agree to the <a href="https://www.measurementlab.net/privacy/">data policy</a>, which includes retention and publication of IP addresses.</label>
             </p>
             <div class="row">
               <div class="col-6">
@@ -55,7 +55,7 @@
               </div>
             </div>
             <small style="font-style: italic;" data-i18n>We are temporarily running multiple tests back to back to calibrate new measurement protocols. This means results may take a little longer to appear than usual. Thank you for your help.</small><br /><br />
-            <small data-i18n data-i18n-html>For more on M-Lab's data collection and measurement, including the disclosure of IP addresses, see our <a href="http://www.measurementlab.net/privacy/">Privacy Policy</a>.</small>
+            <small data-i18n data-i18n-html>For more on M-Lab's data collection and measurement, including the disclosure of IP addresses, see our <a href="https://www.measurementlab.net/privacy/">Privacy Policy</a>.</small>
           </section>
           <section id="measurementSpace">
             <div id="progressSection">
@@ -143,7 +143,7 @@
             </section>
           </div>
           <ul class="actions">
-            <li><a href="http://measurementlab.net" class="button" data-i18n>Learn more</a></li>
+            <li><a href="https://measurementlab.net" class="button" data-i18n>Learn more</a></li>
           </ul>
         </div>
       </section>
@@ -189,9 +189,9 @@
     <footer id="footer" class="wrapper style1-alt">
       <div class="inner">
         <ul class="menu">
-          <li><a href="http://www.measurementlab.net/">Measurement Lab</a></li>
-          <li>Template: <a href="http://html5up.net">HTML5 UP</a></li>
-          <li><a href="http://www.measurementlab.net/privacy/" data-i18n>Privacy Policy</a></li>
+          <li><a href="https://www.measurementlab.net/">Measurement Lab</a></li>
+          <li>Template: <a href="https://html5up.net">HTML5 UP</a></li>
+          <li><a href="https://www.measurementlab.net/privacy/" data-i18n>Privacy Policy</a></li>
         </ul>
       </div>
     </footer>

--- a/translations/languages/az.po
+++ b/translations/languages/az.po
@@ -64,11 +64,11 @@ msgstr "Email"
 msgid ""
 "For more on M-Lab's data collection and measurement, including the "
 "disclosure of IP addresses, see our <a "
-"href=\"http://www.measurementlab.net/privacy/\">Privacy Policy</a>."
+"href=\"https://www.measurementlab.net/privacy/\">Privacy Policy</a>."
 msgstr ""
 "M-Lab-ın İP ünvanların açıqlanması da daxil, məlumatların toplanması və "
 "ölçülməsi ilə bağlı daha ətraflı  <a "
-"href=\"http://www.measurementlab.net/privacy/\">Təhlükəsizlik "
+"href=\"https://www.measurementlab.net/privacy/\">Təhlükəsizlik "
 "Qaydalarına</a> baxın."
 
 #: measure.html:138
@@ -81,11 +81,11 @@ msgstr "Qlobal"
 
 #: measure.html:14
 msgid ""
-"I agree to the <a href=\"http://www.measurementlab.net/privacy/\">data "
+"I agree to the <a href=\"https://www.measurementlab.net/privacy/\">data "
 "policy</a>, which includes retention and publication of IP addresses."
 msgstr ""
 "İP ünvanların saxlanılması və yayımını nəzərdə tutan <a "
-"href=\"http://www.measurementlab.net/privacy/\">məlumat qaydalarını</a>qəbul"
+"href=\"https://www.measurementlab.net/privacy/\">məlumat qaydalarını</a>qəbul"
 " edirəm."
 
 #: measure.js:79 measure.js:82

--- a/translations/languages/br.po
+++ b/translations/languages/br.po
@@ -65,11 +65,11 @@ msgstr "Postel"
 msgid ""
 "For more on M-Lab's data collection and measurement, including the "
 "disclosure of IP addresses, see our <a "
-"href=\"http://www.measurementlab.net/privacy/\">Privacy Policy</a>."
+"href=\"https://www.measurementlab.net/privacy/\">Privacy Policy</a>."
 msgstr ""
 "Evit gouzout hiroc'h war dastumadeg ha muzulioù M-Lab's, diskuliadur ar "
 "chomlec'hioù IP hag all, gwelet hon <a "
-"href=\"http://www.measurementlab.net/privacy/\">Politikerezh Buhez "
+"href=\"https://www.measurementlab.net/privacy/\">Politikerezh Buhez "
 "Prevez</a>."
 
 #: measure.html:138
@@ -82,11 +82,11 @@ msgstr "Hollek"
 
 #: measure.html:14
 msgid ""
-"I agree to the <a href=\"http://www.measurementlab.net/privacy/\">data "
+"I agree to the <a href=\"https://www.measurementlab.net/privacy/\">data "
 "policy</a>, which includes retention and publication of IP addresses."
 msgstr ""
 "Asantiñ a ran d'ar <a "
-"href=\"http://www.measurementlab.net/privacy/\">politikerezh war ar "
+"href=\"https://www.measurementlab.net/privacy/\">politikerezh war ar "
 "roadennoù</a>, dalc'hadur hag embannadur ar chomlec'hioù IP hag all."
 
 #: measure.js:79 measure.js:82

--- a/translations/languages/de_DE.po
+++ b/translations/languages/de_DE.po
@@ -65,11 +65,11 @@ msgstr "E-Mail"
 msgid ""
 "For more on M-Lab's data collection and measurement, including the "
 "disclosure of IP addresses, see our <a "
-"href=\"http://www.measurementlab.net/privacy/\">Privacy Policy</a>."
+"href=\"https://www.measurementlab.net/privacy/\">Privacy Policy</a>."
 msgstr ""
 "Mehr über die M-Lab Datenerhebung und-Messung, einschliesslich der "
 "Weitergabe von IP-Adressen finden Sie in unserer <a "
-"href=\"http://www.measurementlab.net/privacy/\">Datenschutzerklärung</a>."
+"href=\"https://www.measurementlab.net/privacy/\">Datenschutzerklärung</a>."
 
 #: measure.html:138
 msgid "GitHub"
@@ -81,11 +81,11 @@ msgstr "Global"
 
 #: measure.html:14
 msgid ""
-"I agree to the <a href=\"http://www.measurementlab.net/privacy/\">data "
+"I agree to the <a href=\"https://www.measurementlab.net/privacy/\">data "
 "policy</a>, which includes retention and publication of IP addresses."
 msgstr ""
 "Ich stimme dem <a "
-"href=\"http://www.measurementlab.net/privacy/\">Datenschutz</a>zu, der ie "
+"href=\"https://www.measurementlab.net/privacy/\">Datenschutz</a>zu, der ie "
 "Aufbewahrung und Veröffentlichung der IP-Adressen umfasst."
 
 #: measure.js:79 measure.js:82

--- a/translations/languages/el.po
+++ b/translations/languages/el.po
@@ -65,11 +65,11 @@ msgstr "Εmail"
 msgid ""
 "For more on M-Lab's data collection and measurement, including the "
 "disclosure of IP addresses, see our <a "
-"href=\"http://www.measurementlab.net/privacy/\">Privacy Policy</a>."
+"href=\"https://www.measurementlab.net/privacy/\">Privacy Policy</a>."
 msgstr ""
 "Για περισσότερα σχετικά με την συλλογή δεδομένων και μέτρησης του M-Lab, "
 "συμπεριλαμβανομένης της δημοσιοποίησης των διευθύνσεων IP, δείτε την <a "
-"href=\"http://www.measurementlab.net/privacy/\">Ιδιωτική Πολιτική</a> μας. "
+"href=\"https://www.measurementlab.net/privacy/\">Ιδιωτική Πολιτική</a> μας. "
 
 #: measure.html:138
 msgid "GitHub"
@@ -81,10 +81,10 @@ msgstr "Παγκόσμια"
 
 #: measure.html:14
 msgid ""
-"I agree to the <a href=\"http://www.measurementlab.net/privacy/\">data "
+"I agree to the <a href=\"https://www.measurementlab.net/privacy/\">data "
 "policy</a>, which includes retention and publication of IP addresses."
 msgstr ""
-"Συμφωνώ με την <a href=\"http://www.measurementlab.net/privacy/\">πολιτική "
+"Συμφωνώ με την <a href=\"https://www.measurementlab.net/privacy/\">πολιτική "
 "δεδομένων</a>, η οποία περιλαμβάνει τη διατήρηση και τη δημοσίευση "
 "διευθύνσεων IP."
 

--- a/translations/languages/es.po
+++ b/translations/languages/es.po
@@ -65,11 +65,11 @@ msgstr "Correo electrónico"
 msgid ""
 "For more on M-Lab's data collection and measurement, including the "
 "disclosure of IP addresses, see our <a "
-"href=\"http://www.measurementlab.net/privacy/\">Privacy Policy</a>."
+"href=\"https://www.measurementlab.net/privacy/\">Privacy Policy</a>."
 msgstr ""
 "Para más información sobre la recogida de datos y medición de M-Lab, "
 "incluyendo la divulgación de direcciones IP, vea nuestra <a "
-"href=\"http://www.measurementlab.net/privacy/\">Política de privacidad</a>."
+"href=\"https://www.measurementlab.net/privacy/\">Política de privacidad</a>."
 
 #: measure.html:138
 msgid "GitHub"
@@ -81,10 +81,10 @@ msgstr "Global"
 
 #: measure.html:14
 msgid ""
-"I agree to the <a href=\"http://www.measurementlab.net/privacy/\">data "
+"I agree to the <a href=\"https://www.measurementlab.net/privacy/\">data "
 "policy</a>, which includes retention and publication of IP addresses."
 msgstr ""
-"Acepto la <a href=\"http://www.measurementlab.net/privacy/\">política de "
+"Acepto la <a href=\"https://www.measurementlab.net/privacy/\">política de "
 "datos</a>, que incluye retención y publicación de direcciones IP."
 
 #: measure.js:79 measure.js:82

--- a/translations/languages/fa.po
+++ b/translations/languages/fa.po
@@ -63,10 +63,10 @@ msgstr "ایمیل"
 msgid ""
 "For more on M-Lab's data collection and measurement, including the "
 "disclosure of IP addresses, see our <a "
-"href=\"http://www.measurementlab.net/privacy/\">Privacy Policy</a>."
+"href=\"https://www.measurementlab.net/privacy/\">Privacy Policy</a>."
 msgstr ""
 "برای اطلاعات بیشتر در خصوص جمع‌آوری داده M-Lab و سنجش، شامل افشای آدرس‌های "
-"Ip، <a href=\"http://www.measurementlab.net/privacy/\">سیاست حریم خصوصی</a> "
+"Ip، <a href=\"https://www.measurementlab.net/privacy/\">سیاست حریم خصوصی</a> "
 "ما را ببینید."
 
 #: measure.html:138
@@ -79,10 +79,10 @@ msgstr "جهانی"
 
 #: measure.html:14
 msgid ""
-"I agree to the <a href=\"http://www.measurementlab.net/privacy/\">data "
+"I agree to the <a href=\"https://www.measurementlab.net/privacy/\">data "
 "policy</a>, which includes retention and publication of IP addresses."
 msgstr ""
-"من <a href=\"http://www.measurementlab.net/privacy/\">سیاست داده‌ها</a> را "
+"من <a href=\"https://www.measurementlab.net/privacy/\">سیاست داده‌ها</a> را "
 "که شامل نگهداری و انتشار آدرس‌های IP است را قبول دارم."
 
 #: measure.js:79 measure.js:82

--- a/translations/languages/fr.po
+++ b/translations/languages/fr.po
@@ -65,11 +65,11 @@ msgstr "Courriel"
 msgid ""
 "For more on M-Lab's data collection and measurement, including the "
 "disclosure of IP addresses, see our <a "
-"href=\"http://www.measurementlab.net/privacy/\">Privacy Policy</a>."
+"href=\"https://www.measurementlab.net/privacy/\">Privacy Policy</a>."
 msgstr ""
 "Pour en apprendre davantage sur la collecte de données et les mesures de "
 "M-Lab, incluant la divulgation des adresses IP, consulter notre <a "
-"href=\"http://www.measurementlab.net/privacy/\">politique de "
+"href=\"https://www.measurementlab.net/privacy/\">politique de "
 "confidentialité</a>."
 
 #: measure.html:138
@@ -82,10 +82,10 @@ msgstr "Mondial"
 
 #: measure.html:14
 msgid ""
-"I agree to the <a href=\"http://www.measurementlab.net/privacy/\">data "
+"I agree to the <a href=\"https://www.measurementlab.net/privacy/\">data "
 "policy</a>, which includes retention and publication of IP addresses."
 msgstr ""
-"J'accepte la <a href=\"http://www.measurementlab.net/privacy/\">politique "
+"J'accepte la <a href=\"https://www.measurementlab.net/privacy/\">politique "
 "des données</a> qui inclut la conservation et la publication des adresses "
 "IP."
 

--- a/translations/languages/hi.po
+++ b/translations/languages/hi.po
@@ -63,10 +63,10 @@ msgstr "ईमेल"
 msgid ""
 "For more on M-Lab's data collection and measurement, including the "
 "disclosure of IP addresses, see our <a "
-"href=\"http://www.measurementlab.net/privacy/\">Privacy Policy</a>."
+"href=\"https://www.measurementlab.net/privacy/\">Privacy Policy</a>."
 msgstr ""
 "एम-लैब के डेटा संग्रह और माप के बारे में अधिक जानकारी के लिए, आईपी पते के "
-"प्रकटीकरण सहित, हमारी <a href=\"http://www.measurementlab.net/privacy/\"> "
+"प्रकटीकरण सहित, हमारी <a href=\"https://www.measurementlab.net/privacy/\"> "
 "गोपनीयता नीति </a> देखें।"
 
 #: measure.html:138
@@ -79,10 +79,10 @@ msgstr "ग्लोबल"
 
 #: measure.html:14
 msgid ""
-"I agree to the <a href=\"http://www.measurementlab.net/privacy/\">data "
+"I agree to the <a href=\"https://www.measurementlab.net/privacy/\">data "
 "policy</a>, which includes retention and publication of IP addresses."
 msgstr ""
-"मैं <a href=\"http://www.measurementlab.net/privacy/\"> डेटा नीति </a> से "
+"मैं <a href=\"https://www.measurementlab.net/privacy/\"> डेटा नीति </a> से "
 "सहमत हूं, जिसमें आईपी पते के प्रतिधारण और प्रकाशन शामिल हैं I"
 
 #: measure.js:79 measure.js:82

--- a/translations/languages/id.po
+++ b/translations/languages/id.po
@@ -64,11 +64,11 @@ msgstr "Surel"
 msgid ""
 "For more on M-Lab's data collection and measurement, including the "
 "disclosure of IP addresses, see our <a "
-"href=\"http://www.measurementlab.net/privacy/\">Privacy Policy</a>."
+"href=\"https://www.measurementlab.net/privacy/\">Privacy Policy</a>."
 msgstr ""
 "Untuk lebih lanjut tentang pengumpulan data dan pengukuran M-Lab, termasuk "
 "keterbukaan alamat IP, lihat <a "
-"href=\"http://www.measurementlab.net/privacy/\">Kebijakan Privasi</a>."
+"href=\"https://www.measurementlab.net/privacy/\">Kebijakan Privasi</a>."
 
 #: measure.html:138
 msgid "GitHub"
@@ -80,11 +80,11 @@ msgstr "Global"
 
 #: measure.html:14
 msgid ""
-"I agree to the <a href=\"http://www.measurementlab.net/privacy/\">data "
+"I agree to the <a href=\"https://www.measurementlab.net/privacy/\">data "
 "policy</a>, which includes retention and publication of IP addresses."
 msgstr ""
 "Saya setuju dengan <a "
-"href=\"http://www.measurementlab.net/privacy/\">kebijakan data</a>, termasuk"
+"href=\"https://www.measurementlab.net/privacy/\">kebijakan data</a>, termasuk"
 " penyimpanan dan publikasi alamat IP."
 
 #: measure.js:79 measure.js:82

--- a/translations/languages/it.po
+++ b/translations/languages/it.po
@@ -66,11 +66,11 @@ msgstr "Email"
 msgid ""
 "For more on M-Lab's data collection and measurement, including the "
 "disclosure of IP addresses, see our <a "
-"href=\"http://www.measurementlab.net/privacy/\">Privacy Policy</a>."
+"href=\"https://www.measurementlab.net/privacy/\">Privacy Policy</a>."
 msgstr ""
 "Per maggiori informazioni sulla raccolta dati e le misurazioni di M-Lab, "
 "inclusa la divulgazione degli indirizzi IP, consulta la nostra <a "
-"href=\"http://www.measurementlab.net/privacy/\">Informativa sulla Privacy</a>."
+"href=\"https://www.measurementlab.net/privacy/\">Informativa sulla Privacy</a>."
 
 #: measure.html:138
 msgid "GitHub"
@@ -82,10 +82,10 @@ msgstr "Globale"
 
 #: measure.html:14
 msgid ""
-"I agree to the <a href=\"http://www.measurementlab.net/privacy/\">data "
+"I agree to the <a href=\"https://www.measurementlab.net/privacy/\">data "
 "policy</a>, which includes retention and publication of IP addresses."
 msgstr ""
-"Accetto la <a href=\"http://www.measurementlab.net/privacy/\">politica sui "
+"Accetto la <a href=\"https://www.measurementlab.net/privacy/\">politica sui "
 "dati</a>, che include la conservazione e la pubblicazione degli indirizzi IP."
 
 #: measure.js:79 measure.js:82

--- a/translations/languages/nl.po
+++ b/translations/languages/nl.po
@@ -65,11 +65,11 @@ msgstr "Email"
 msgid ""
 "For more on M-Lab's data collection and measurement, including the "
 "disclosure of IP addresses, see our <a "
-"href=\"http://www.measurementlab.net/privacy/\">Privacy Policy</a>."
+"href=\"https://www.measurementlab.net/privacy/\">Privacy Policy</a>."
 msgstr ""
 "Voor meer informatie over M-Lab's gegevensverzameling en data-analyse, "
 "inclusief het publiceren van IP-adressen, zie ons  <a "
-"href=\"http://www.measurementlab.net/privacy/\">Privacybeleid</a>."
+"href=\"https://www.measurementlab.net/privacy/\">Privacybeleid</a>."
 
 #: measure.html:138
 msgid "GitHub"
@@ -81,11 +81,11 @@ msgstr "Wereldwijd"
 
 #: measure.html:14
 msgid ""
-"I agree to the <a href=\"http://www.measurementlab.net/privacy/\">data "
+"I agree to the <a href=\"https://www.measurementlab.net/privacy/\">data "
 "policy</a>, which includes retention and publication of IP addresses."
 msgstr ""
 "Ik ga akkoord met het <a "
-"href=\"http://www.measurementlab.net/privacy/\">gegevensbeleid</a>, "
+"href=\"https://www.measurementlab.net/privacy/\">gegevensbeleid</a>, "
 "inclusief het opslaan en de publicatie van IP-adressen."
 
 #: measure.js:79 measure.js:82

--- a/translations/languages/pt_PT.po
+++ b/translations/languages/pt_PT.po
@@ -66,11 +66,11 @@ msgstr "E-mail"
 msgid ""
 "For more on M-Lab's data collection and measurement, including the "
 "disclosure of IP addresses, see our <a "
-"href=\"http://www.measurementlab.net/privacy/\">Privacy Policy</a>."
+"href=\"https://www.measurementlab.net/privacy/\">Privacy Policy</a>."
 msgstr ""
 "Para mais sobre a recolha de dados e medição de M-Lab, incluindo a "
 "divulgação dos endereços de IP, consulte a nossa <a "
-"href=\"http://www.measurementlab.net/privacy/\">Política de Privacidade</a>."
+"href=\"https://www.measurementlab.net/privacy/\">Política de Privacidade</a>."
 
 #: measure.html:138
 msgid "GitHub"
@@ -82,11 +82,11 @@ msgstr "Global"
 
 #: measure.html:14
 msgid ""
-"I agree to the <a href=\"http://www.measurementlab.net/privacy/\">data "
+"I agree to the <a href=\"https://www.measurementlab.net/privacy/\">data "
 "policy</a>, which includes retention and publication of IP addresses."
 msgstr ""
 "Eu concordo com a <a "
-"href=\"http://www.measurementlab.net/privacy/\">política de dados</a>, que "
+"href=\"https://www.measurementlab.net/privacy/\">política de dados</a>, que "
 "inclui a retenção e publicação dos endereços de IP."
 
 #: measure.js:79 measure.js:82

--- a/translations/languages/ru.po
+++ b/translations/languages/ru.po
@@ -64,11 +64,11 @@ msgstr "Электронная почта"
 msgid ""
 "For more on M-Lab's data collection and measurement, including the "
 "disclosure of IP addresses, see our <a "
-"href=\"http://www.measurementlab.net/privacy/\">Privacy Policy</a>."
+"href=\"https://www.measurementlab.net/privacy/\">Privacy Policy</a>."
 msgstr ""
 "Подробнее о сборе данных и измерениях теста M-Lab, в том  числе, о раскрытии"
 " IP-адресов, смотрите нашу<a "
-"href=\"http://www.measurementlab.net/privacy/\">Политику "
+"href=\"https://www.measurementlab.net/privacy/\">Политику "
 "Конфиденциальности</a>."
 
 #: measure.html:138
@@ -81,10 +81,10 @@ msgstr "Глобальные"
 
 #: measure.html:14
 msgid ""
-"I agree to the <a href=\"http://www.measurementlab.net/privacy/\">data "
+"I agree to the <a href=\"https://www.measurementlab.net/privacy/\">data "
 "policy</a>, which includes retention and publication of IP addresses."
 msgstr ""
-"Я соглашаюсь с<a href=\"http://www.measurementlab.net/privacy/\">политикой "
+"Я соглашаюсь с<a href=\"https://www.measurementlab.net/privacy/\">политикой "
 "данных</a>, которая включает сохранение и публикацию IP-адресов."
 
 #: measure.js:79 measure.js:82

--- a/translations/languages/zh.po
+++ b/translations/languages/zh.po
@@ -59,10 +59,10 @@ msgstr "電子郵件"
 msgid ""
 "For more on M-Lab's data collection and measurement, including the "
 "disclosure of IP addresses, see our <a "
-"href=\"http://www.measurementlab.net/privacy/\">Privacy Policy</a>."
+"href=\"https://www.measurementlab.net/privacy/\">Privacy Policy</a>."
 msgstr ""
 "了解更多M-Lab 在資料收集與測量數據上的東西，包括揭示IP 位置等等，請見我們的<a "
-"href=\"http://www.measurementlab.net/privacy/\">隱私政策</a>。"
+"href=\"https://www.measurementlab.net/privacy/\">隱私政策</a>。"
 
 #: measure.html:138
 msgid "GitHub"
@@ -74,10 +74,10 @@ msgstr "全球的"
 
 #: measure.html:14
 msgid ""
-"I agree to the <a href=\"http://www.measurementlab.net/privacy/\">data "
+"I agree to the <a href=\"https://www.measurementlab.net/privacy/\">data "
 "policy</a>, which includes retention and publication of IP addresses."
 msgstr ""
-"我同意<a href=\"http://www.measurementlab.net/privacy/\">資料政策</a>, 其它括收集保留與公開IP"
+"我同意<a href=\"https://www.measurementlab.net/privacy/\">資料政策</a>, 其它括收集保留與公開IP"
 " 地址資料。"
 
 #: measure.js:79 measure.js:82

--- a/translations/source/application.pot
+++ b/translations/source/application.pot
@@ -48,7 +48,7 @@ msgid "Email"
 msgstr ""
 
 #: measure.html:33
-msgid "For more on M-Lab's data collection and measurement, including the disclosure of IP addresses, see our <a href=\"http://www.measurementlab.net/privacy/\">Privacy Policy</a>."
+msgid "For more on M-Lab's data collection and measurement, including the disclosure of IP addresses, see our <a href=\"https://www.measurementlab.net/privacy/\">Privacy Policy</a>."
 msgstr ""
 
 #: measure.html:141
@@ -60,7 +60,7 @@ msgid "Global"
 msgstr ""
 
 #: measure.html:15
-msgid "I agree to the <a href=\"http://www.measurementlab.net/privacy/\">data policy</a>, which includes retention and publication of IP addresses."
+msgid "I agree to the <a href=\"https://www.measurementlab.net/privacy/\">data policy</a>, which includes retention and publication of IP addresses."
 msgstr ""
 
 #: measure.js:67


### PR DESCRIPTION
Fixes #184

## What changed
- Replaced remaining `http://` links with `https://` in `src/index.html`.
- Updated `translations/source/application.pot` and translation `.po` files so i18n HTML keys stay consistent.

## Testing
- npm run build -- staging
