### PR TITLE
fix: guard against division by zero in NDT7 result calculations

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -248,9 +248,10 @@ const SpeedTest = {
           if (data.LastServerMeasurement?.TCPInfo) {
             this.measurementResult.latency =
               (data.LastServerMeasurement.TCPInfo.MinRTT / 1000).toFixed(0) + ' ms';
-            this.measurementResult.loss =
-              (data.LastServerMeasurement.TCPInfo.BytesRetrans /
-                data.LastServerMeasurement.TCPInfo.BytesSent * 100).toFixed(2) + '%';
+            this.measurementResult.loss = data.LastServerMeasurement.TCPInfo.BytesSent
+              ? (data.LastServerMeasurement.TCPInfo.BytesRetrans /
+                  data.LastServerMeasurement.TCPInfo.BytesSent * 100).toFixed(2) + '%'
+              : '0.00%';
             this.els.latency.textContent = this.measurementResult.latency;
             this.els.loss.textContent = this.measurementResult.loss;
           }
@@ -262,8 +263,10 @@ const SpeedTest = {
         },
         uploadMeasurement: (data) => {
           if (data.Source === 'server') {
-            this.els.currentSpeed.textContent = (data.Data.TCPInfo.BytesReceived /
-              data.Data.TCPInfo.ElapsedTime * 8).toFixed(2) + ' Mb/s';
+            this.els.currentSpeed.textContent = data.Data.TCPInfo.ElapsedTime
+              ? (data.Data.TCPInfo.BytesReceived /
+                  data.Data.TCPInfo.ElapsedTime * 8).toFixed(2) + ' Mb/s'
+              : '0.00 Mb/s';
           }
           if (data.Source === 'client') {
             const progress = (data.Data.ElapsedTime > this.TIME_EXPECTED) ? 1.0 :
@@ -273,9 +276,10 @@ const SpeedTest = {
         },
         uploadComplete: (data) => {
           if (data.LastServerMeasurement?.TCPInfo) {
-            this.measurementResult.c2sRate =
-              (data.LastServerMeasurement.TCPInfo.BytesReceived /
-                data.LastServerMeasurement.TCPInfo.ElapsedTime * 8).toFixed(2) + ' Mb/s';
+            this.measurementResult.c2sRate = data.LastServerMeasurement.TCPInfo.ElapsedTime
+              ? (data.LastServerMeasurement.TCPInfo.BytesReceived /
+                  data.LastServerMeasurement.TCPInfo.ElapsedTime * 8).toFixed(2) + ' Mb/s'
+              : '0.00 Mb/s';
             this.els.c2sRate.textContent = this.measurementResult.c2sRate;
           }
         },


### PR DESCRIPTION
## Description  

### Problem  
I noticed that three division operations in the NDT7 result callbacks didn’t have zero-value checks. When `BytesSent` or `ElapsedTime` is `0` (for example, during very short or failed connections), the UI shows `NaN%`, `Infinity Mb/s`, or `NaN Mb/s`.  

This breaks user trust in a measurement tool.

Affected calculations:
- **Retransmission loss** → `BytesRetrans / BytesSent * 100`
- **Upload speed (live)** → `BytesReceived / ElapsedTime * 8`
- **Upload speed (final)** → `BytesReceived / ElapsedTime * 8`

---

### Fix  
I added simple ternary guards before each division to ensure we only divide when the divisor is valid.  

If the divisor is `0`, `null`, or `undefined`, the UI now falls back to:
- `0.00%`
- `0.00 Mb/s`

---

## Test Plan  

- Run a full speed test and verify results display correctly.  
- Simulate cases where `BytesSent` or `ElapsedTime` is `0` and confirm `0.00%` / `0.00 Mb/s` is shown instead of `NaN` or `Infinity`. 