### PR TITLE
docs: update broken transifex link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The `mlab-speedtest` repository implements the https://speed.measurementlab.net/
 
 ## Adding new languages
 
-Translations for this site are managed in the [Open Technology Fund's Localization Lab Transifex site](https://www.transifex.com/otf/m-lab-ndt-portal/dashboard/). Contributing translators may choose to translate and/or review translations there. Completed translations are then imported for use within this application and published by M-Lab staff.
+Translations for this site are managed in the [Open Technology Fund's Localization Lab Transifex site](https://explore.transifex.com/otf/m-lab-ndt-portal/). Contributing translators may choose to translate and/or review translations there. Completed translations are then imported for use within this application and published by M-Lab staff.
 
 ### How to add a new localization
 


### PR DESCRIPTION
Fixes #192

This PR updates the broken transifex link in README.md, before the link was returning a 404 page, now i have updated it to the correct link.

Old link: https://www.transifex.com/otf/m-lab-ndt-portal/dashboard/
New link: https://explore.transifex.com/otf/m-lab-ndt-portal/