### PR TITLE
fix: social media icons rendering as square placeholders

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -173,8 +173,8 @@
                 <li>
                   <h3 data-i18n>Social</h3>
                   <ul class="icons">
-                    <li><a href="https://twitter.com/MeasurementLab" class="fa-twitter" target="_blank"><span class="label" data-i18n>Twitter</span></a></li>
-                    <li><a href="https://github.com/m-lab" class="fa-github" target="_blank"><span class="label" data-i18n>GitHub</span></a></li>
+                    <li><a href="https://twitter.com/MeasurementLab" class="fa fa-twitter" target="_blank"> <span class="label" data-i18n>Twitter</span></a></li>
+                    <li><a href="https://github.com/m-lab" class="fa fa-github" target="_blank"> <span class="label" data-i18n>GitHub</span></a></li>
                   </ul>
                 </li>
               </ul>


### PR DESCRIPTION
## Fix: Social icons rendering issue

### Problem
Icons were displaying as square placeholders due to missing base `fa` class.

### Solution
Added the required `fa` base class to the Twitter and GitHub icons.

### Before
<img width="791" height="401" alt="image" src="https://github.com/user-attachments/assets/f62b9d57-418d-4393-b58d-b7d2f865c788" />

### After
<img width="819" height="429" alt="image" src="https://github.com/user-attachments/assets/9f58ec1a-bf46-43ba-a8ad-8f2d0ca72bfd" />

Closes #201 