### PR TITLE
fix: Uneven space around BEGIN button

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -179,9 +179,9 @@ body {
    ============================================ */
 .row {
   display: flex;
+  flex-direction: column;
   flex-wrap: wrap;
   gap: 1.5em;
-  margin-bottom: 34px;
 }
 
 .row > * {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -181,6 +181,7 @@ body {
   display: flex;
   flex-wrap: wrap;
   gap: 1.5em;
+  margin-bottom: 34px;
 }
 
 .row > * {


### PR DESCRIPTION
## Solution 
Increases the margin from the bottom of the component which manages the uneven space around it 

## Checks 
Also checked in the responsive manner.

## Preview
<img width="1919" height="961" alt="image" src="https://github.com/user-attachments/assets/149d56e2-fe9c-42a1-bf82-fbeca2215223" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-speedtest/208)
<!-- Reviewable:end -->
