### PR TITLE
Refactor: Create unified TestResults class for measurement data

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -204,6 +204,7 @@
     <script src="js/env.js"></script>
     <script src="js/i18n.js"></script>
     <script src="js/gauge.js"></script>
+    <script src="js/test-results.js"></script>
     <script src="js/app.js"></script>
 
     <!-- Google tag (gtag.js) -->

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -9,8 +9,7 @@ const SpeedTest = {
   testRunning: false,
   privacyConsent: false,
   measurementComplete: false,
-  measurementResult: {},
-  msakResult: {},
+  testResults: null, // Unified TestResults instance
 
   // DOM elements (cached on init)
   els: {},
@@ -120,8 +119,6 @@ const SpeedTest = {
     ProgressGauge.reset();
     this.testRunning = true;
     this.measurementComplete = false;
-    this.measurementResult = {};
-    this.msakResult = {};
     this.updateUI();
 
     // Scroll to measurement area on mobile
@@ -132,8 +129,9 @@ const SpeedTest = {
     this.els.currentSpeed.textContent = i18n.t('Starting');
     this.els.currentPhase.textContent = '';
 
-    // Generate a random UUID
+    // Generate a random UUID and create TestResults instance
     const sessionID = crypto.randomUUID();
+    this.testResults = new TestResults(sessionID);
 
     // Randomly choose which test to start first
     try {
@@ -221,7 +219,8 @@ const SpeedTest = {
           if (window.Sentry) Sentry.captureException(err, { tags: { test: 'ndt7' } });
         },
         serverChosen: (server) => {
-          this.els.location.textContent = server.location.city + ', ' + server.location.country;
+          this.testResults.setNdt7Server(server);
+          this.els.location.textContent = this.testResults.getNdt7Location();
           console.log('[ndt7] Testing to:', {
             machine: server.machine,
             locations: server.location,
@@ -241,18 +240,19 @@ const SpeedTest = {
         },
         downloadComplete: (data) => {
           if (data.LastClientMeasurement) {
-            this.measurementResult.s2cRate =
-              data.LastClientMeasurement.MeanClientMbps.toFixed(2) + ' Mb/s';
-            this.els.s2cRate.textContent = this.measurementResult.s2cRate;
+            this.testResults.setNdt7Download(data.LastClientMeasurement.MeanClientMbps);
+            this.els.s2cRate.textContent = this.testResults.ndt7.download.formatted;
           }
           if (data.LastServerMeasurement?.TCPInfo) {
-            this.measurementResult.latency =
-              (data.LastServerMeasurement.TCPInfo.MinRTT / 1000).toFixed(0) + ' ms';
-            this.measurementResult.loss =
-              (data.LastServerMeasurement.TCPInfo.BytesRetrans /
-                data.LastServerMeasurement.TCPInfo.BytesSent * 100).toFixed(2) + '%';
-            this.els.latency.textContent = this.measurementResult.latency;
-            this.els.loss.textContent = this.measurementResult.loss;
+            const latencyMs = data.LastServerMeasurement.TCPInfo.MinRTT / 1000;
+            const retransPercent = (data.LastServerMeasurement.TCPInfo.BytesRetrans /
+              data.LastServerMeasurement.TCPInfo.BytesSent * 100);
+            
+            this.testResults.setNdt7Latency(latencyMs);
+            this.testResults.setNdt7Retransmission(retransPercent);
+            
+            this.els.latency.textContent = this.testResults.ndt7.latency.formatted;
+            this.els.loss.textContent = this.testResults.ndt7.retransmission.formatted;
           }
           console.log(data);
         },
@@ -273,10 +273,11 @@ const SpeedTest = {
         },
         uploadComplete: (data) => {
           if (data.LastServerMeasurement?.TCPInfo) {
-            this.measurementResult.c2sRate =
-              (data.LastServerMeasurement.TCPInfo.BytesReceived /
-                data.LastServerMeasurement.TCPInfo.ElapsedTime * 8).toFixed(2) + ' Mb/s';
-            this.els.c2sRate.textContent = this.measurementResult.c2sRate;
+            const uploadSpeedMbps = data.LastServerMeasurement.TCPInfo.BytesReceived /
+              data.LastServerMeasurement.TCPInfo.ElapsedTime * 8;
+            
+            this.testResults.setNdt7Upload(uploadSpeedMbps);
+            this.els.c2sRate.textContent = this.testResults.ndt7.upload.formatted;
           }
         },
       },
@@ -291,19 +292,22 @@ const SpeedTest = {
       },
       onDownloadStart: (server) => {
         console.log('[msak] Server: ' + server.machine);
-        this.els.msakLocation.textContent = server.location.city + ', ' + server.location.country;
+        this.testResults.setMsakServer(server);
+        this.els.msakLocation.textContent = this.testResults.getMsakLocation();
       },
       onDownloadResult: (result) => {
-        this.msakResult.download = result.goodput.toFixed(2) + ' Mb/s';
-        this.els.msakDownload.textContent = this.msakResult.download;
+        this.testResults.setMsakDownload(result.goodput);
+        this.els.msakDownload.textContent = this.testResults.msak.download.formatted;
+        
         if (result.retransmission != null && !isNaN(result.retransmission)) {
-          this.msakResult.loss = (result.retransmission * 100).toFixed(2) + '%';
-          this.els.msakLoss.textContent = this.msakResult.loss;
+          this.testResults.setMsakRetransmission(result.retransmission * 100);
+          this.els.msakLoss.textContent = this.testResults.msak.retransmission.formatted;
         }
         if (result.minRTT != null) {
-          this.msakResult.latency = (result.minRTT / 1000).toFixed(0) + ' ms';
-          this.els.msakLatency.textContent = this.msakResult.latency;
+          this.testResults.setMsakLatency(result.minRTT / 1000);
+          this.els.msakLatency.textContent = this.testResults.msak.latency.formatted;
         }
+        
         this.els.currentPhase.textContent = i18n.t('Download');
         this.els.currentSpeed.textContent = result.goodput.toFixed(2) + ' Mb/s';
         const progress = (result.elapsed > this.TIME_EXPECTED) ? 0.5 :
@@ -311,10 +315,10 @@ const SpeedTest = {
         ProgressGauge.progress(progress);
       },
       onUploadResult: (result) => {
-        this.msakResult.upload = result.goodput.toFixed(2) + ' Mb/s';
+        this.testResults.setMsakUpload(result.goodput);
         this.els.currentPhase.textContent = i18n.t('Upload');
         this.els.currentSpeed.textContent = result.goodput.toFixed(2) + ' Mb/s';
-        this.els.msakUpload.textContent = this.msakResult.upload;
+        this.els.msakUpload.textContent = this.testResults.msak.upload.formatted;
         const progress = (result.elapsed > this.TIME_EXPECTED) ? 1.0 :
           result.elapsed / (this.TIME_EXPECTED * 2) + 0.5;
         ProgressGauge.progress(progress);

--- a/src/js/test-results.js
+++ b/src/js/test-results.js
@@ -1,0 +1,227 @@
+'use strict';
+
+/**
+ * TestResults - Unified data structure for NDT7 and MSAK measurement results
+ * 
+ * This class provides a consistent interface for storing, accessing, and
+ * exporting speed test results from both measurement protocols.
+ */
+class TestResults {
+  constructor(sessionId) {
+    this.sessionId = sessionId;
+    this.timestamp = new Date().toISOString();
+    this.clientInfo = this._getClientInfo();
+    
+    // NDT7 protocol results
+    this.ndt7 = {
+      server: {
+        city: null,
+        country: null,
+        machine: null
+      },
+      download: {
+        speed: null,
+        unit: 'Mb/s',
+        formatted: null
+      },
+      upload: {
+        speed: null,
+        unit: 'Mb/s',
+        formatted: null
+      },
+      latency: {
+        value: null,
+        unit: 'ms',
+        formatted: null
+      },
+      retransmission: {
+        value: null,
+        unit: '%',
+        formatted: null
+      }
+    };
+    
+    // MSAK protocol results
+    this.msak = {
+      server: {
+        city: null,
+        country: null,
+        machine: null
+      },
+      download: {
+        speed: null,
+        unit: 'Mb/s',
+        formatted: null
+      },
+      upload: {
+        speed: null,
+        unit: 'Mb/s',
+        formatted: null
+      },
+      latency: {
+        value: null,
+        unit: 'ms',
+        formatted: null
+      },
+      retransmission: {
+        value: null,
+        unit: '%',
+        formatted: null
+      }
+    };
+  }
+
+  /**
+   * Collect basic client information
+   * @private
+   */
+  _getClientInfo() {
+    return {
+      userAgent: navigator.userAgent,
+      language: navigator.language,
+      platform: navigator.platform,
+      screenResolution: `${window.screen.width}x${window.screen.height}`,
+      viewport: `${window.innerWidth}x${window.innerHeight}`
+    };
+  }
+
+  // NDT7 Setters
+  
+  setNdt7Server(server) {
+    if (server && server.location) {
+      this.ndt7.server.city = server.location.city;
+      this.ndt7.server.country = server.location.country;
+      this.ndt7.server.machine = server.machine;
+    }
+  }
+
+  setNdt7Download(speedMbps) {
+    this.ndt7.download.speed = speedMbps;
+    this.ndt7.download.formatted = speedMbps.toFixed(2) + ' Mb/s';
+  }
+
+  setNdt7Upload(speedMbps) {
+    this.ndt7.upload.speed = speedMbps;
+    this.ndt7.upload.formatted = speedMbps.toFixed(2) + ' Mb/s';
+  }
+
+  setNdt7Latency(latencyMs) {
+    this.ndt7.latency.value = latencyMs;
+    this.ndt7.latency.formatted = latencyMs.toFixed(0) + ' ms';
+  }
+
+  setNdt7Retransmission(retransPercent) {
+    this.ndt7.retransmission.value = retransPercent;
+    this.ndt7.retransmission.formatted = retransPercent.toFixed(2) + '%';
+  }
+
+  // MSAK Setters
+
+  setMsakServer(server) {
+    if (server && server.location) {
+      this.msak.server.city = server.location.city;
+      this.msak.server.country = server.location.country;
+      this.msak.server.machine = server.machine;
+    }
+  }
+
+  setMsakDownload(speedMbps) {
+    this.msak.download.speed = speedMbps;
+    this.msak.download.formatted = speedMbps.toFixed(2) + ' Mb/s';
+  }
+
+  setMsakUpload(speedMbps) {
+    this.msak.upload.speed = speedMbps;
+    this.msak.upload.formatted = speedMbps.toFixed(2) + ' Mb/s';
+  }
+
+  setMsakLatency(latencyMs) {
+    this.msak.latency.value = latencyMs;
+    this.msak.latency.formatted = latencyMs.toFixed(0) + ' ms';
+  }
+
+  setMsakRetransmission(retransPercent) {
+    this.msak.retransmission.value = retransPercent;
+    this.msak.retransmission.formatted = retransPercent.toFixed(2) + '%';
+  }
+
+  // Getters for formatted values (backward compatibility)
+
+  getNdt7Location() {
+    if (this.ndt7.server.city && this.ndt7.server.country) {
+      return `${this.ndt7.server.city}, ${this.ndt7.server.country}`;
+    }
+    return null;
+  }
+
+  getMsakLocation() {
+    if (this.msak.server.city && this.msak.server.country) {
+      return `${this.msak.server.city}, ${this.msak.server.country}`;
+    }
+    return null;
+  }
+
+  // Utility methods
+
+  /**
+   * Calculate average download speed across both protocols
+   * @returns {number|null} Average speed in Mb/s or null if no data
+   */
+  getAverageDownload() {
+    const speeds = [this.ndt7.download.speed, this.msak.download.speed].filter(s => s !== null);
+    if (speeds.length === 0) return null;
+    return speeds.reduce((a, b) => a + b, 0) / speeds.length;
+  }
+
+  /**
+   * Calculate average upload speed across both protocols
+   * @returns {number|null} Average speed in Mb/s or null if no data
+   */
+  getAverageUpload() {
+    const speeds = [this.ndt7.upload.speed, this.msak.upload.speed].filter(s => s !== null);
+    if (speeds.length === 0) return null;
+    return speeds.reduce((a, b) => a + b, 0) / speeds.length;
+  }
+
+  /**
+   * Check if test results are complete
+   * @returns {boolean} True if both protocols have results
+   */
+  isComplete() {
+    return this.ndt7.download.speed !== null && 
+           this.msak.download.speed !== null;
+  }
+
+  /**
+   * Export results as JSON
+   * @returns {string} JSON string of all results
+   */
+  toJSON() {
+    return JSON.stringify({
+      sessionId: this.sessionId,
+      timestamp: this.timestamp,
+      clientInfo: this.clientInfo,
+      ndt7: this.ndt7,
+      msak: this.msak
+    }, null, 2);
+  }
+
+  /**
+   * Export results as plain object
+   * @returns {Object} Plain object representation
+   */
+  toObject() {
+    return {
+      sessionId: this.sessionId,
+      timestamp: this.timestamp,
+      clientInfo: this.clientInfo,
+      ndt7: this.ndt7,
+      msak: this.msak
+    };
+  }
+}
+
+// Make available globally (for now, until we have a proper module system)
+if (typeof window !== 'undefined') {
+  window.TestResults = TestResults;
+}


### PR DESCRIPTION
## Description

### Why This Change?

Currently, test results from NDT7 and MSAK are stored in separate objects (`measurementResult` and `msakResult`), making it difficult to:
- Compare results between protocols
- Add metadata for future features
- Export or persist results consistently
- Extend functionality for IQB scoring and historical tracking

### What Changed?

Created a `TestResults` class that:
- Centralizes result storage for both protocols
- Includes metadata (sessionId, timestamp, client info)
- Provides utility methods for formatting, averaging, and export
- Maintains backward compatibility with existing UI

### Benefits

- Cleaner architecture with single responsibility
- Easier to maintain and test
- Consistent formatting logic

### Testing

- [x] Build completes successfully
- [x] Local testing with staging environment
- [x] No breaking changes to existing functionality
- [x] Maintains backward compatibility

### Related Issue 
#211 