### PR TITLE
fix: vertically stack notes below the button

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -53,7 +53,7 @@ table.transparent tbody tr:nth-child(2n + 1) {
     padding: 3em 2em 1em 2em;
     width: auto;
   }
-  span.privacyConsentMessage {
+  .privacyConsentMessage {
     display: none;
   }
 }
@@ -116,9 +116,14 @@ canvas.progressGauge {
   }
 }
 
-span.privacyConsentMessage {
+.privacyConsentMessage {
   font-size: small;
   color: rgba(255, 255, 255, 1.0);
+}
+
+.speedtestNotes > * {
+  display: block;
+  margin-top: 1em;
 }
 
 /* ============================================

--- a/src/index.html
+++ b/src/index.html
@@ -42,20 +42,16 @@
               <input type="checkbox" id="privacyConsent" name="privacyConsent">
               <label for="privacyConsent" style="font-size: smaller;" data-i18n data-i18n-html>I agree to the <a href="https://www.measurementlab.net/privacy/">data policy</a>, which includes retention and publication of IP addresses.</label>
             </p>
-            <div class="row">
-              <div class="col-6">
-                <a id="startButton" class="button special startButton big disabled">
-                  <span class="btn-begin"><span data-i18n>Begin</span> <i class="fa fa-play" aria-hidden="true"></i></span>
-                  <span class="btn-again" style="display:none;"><span data-i18n>Again</span> <i class="fa fa-repeat" aria-hidden="true"></i></span>
-                  <span class="btn-testing" style="display:none;"><span data-i18n>Testing</span> <i class="fa fa-circle-o-notch fa-spin" aria-hidden="true"></i></span>
-                </a>
-              </div>
-              <div class="col-6">
-                <span id="privacyMessage" data-i18n class="privacyConsentMessage">Please agree to the data policy prior to the test.</span>
-              </div>
+            <a id="startButton" class="button special startButton big disabled">
+              <span class="btn-begin"><span data-i18n>Begin</span> <i class="fa fa-play" aria-hidden="true"></i></span>
+              <span class="btn-again" style="display:none;"><span data-i18n>Again</span> <i class="fa fa-repeat" aria-hidden="true"></i></span>
+              <span class="btn-testing" style="display:none;"><span data-i18n>Testing</span> <i class="fa fa-circle-o-notch fa-spin" aria-hidden="true"></i></span>
+            </a>
+            <div class="speedtestNotes">
+              <div id="privacyMessage" data-i18n class="privacyConsentMessage">Please agree to the data policy prior to the test.</div>
+              <small style="font-style: italic;" data-i18n>We are temporarily running multiple tests back to back to calibrate new measurement protocols. This means results may take a little longer to appear than usual. Thank you for your help.</small>
+              <small data-i18n data-i18n-html>For more on M-Lab's data collection and measurement, including the disclosure of IP addresses, see our <a href="https://www.measurementlab.net/privacy/">Privacy Policy</a>.</small>
             </div>
-            <small style="font-style: italic;" data-i18n>We are temporarily running multiple tests back to back to calibrate new measurement protocols. This means results may take a little longer to appear than usual. Thank you for your help.</small><br /><br />
-            <small data-i18n data-i18n-html>For more on M-Lab's data collection and measurement, including the disclosure of IP addresses, see our <a href="https://www.measurementlab.net/privacy/">Privacy Policy</a>.</small>
           </section>
           <section id="measurementSpace">
             <div id="progressSection">

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -107,7 +107,7 @@ const SpeedTest = {
     }
 
     // Show/hide privacy message
-    this.els.privacyMessage.style.display = this.privacyConsent ? 'none' : 'inline';
+    this.els.privacyMessage.style.display = this.privacyConsent ? 'none' : 'block';
 
     // Show/hide progress vs results
     this.els.progressSection.style.display = this.measurementComplete ? 'none' : 'block';


### PR DESCRIPTION
Rather than arranging part of the content below the button using two columns, go for vertical stacking of the content.

This changes the way in which `index.html` is rendered so that weird spacing around the "begin" button is gone.

We also deal with the fallback, by changing the CSS and the JS to deal with divs rather than spans now.

While there, zap the inline `<br />` and use margin attached to direct children to visually separate notes paragraphs.

Closes https://github.com/m-lab/mlab-speedtest/issues/199

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-speedtest/221)
<!-- Reviewable:end -->
