### PR TITLE
cleanup: stop running MSAK alongside ndt7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@m-lab/msak": "^0.3.2",
         "@m-lab/ndt7": "0.1.4",
         "@sentry/browser": "^10.59.0"
       },
@@ -437,15 +436,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@m-lab/msak": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@m-lab/msak/-/msak-0.3.2.tgz",
-      "integrity": "sha512-PU/P4O1fzfPZuJs+5MpbpiT8wwQNJCPhZE1FDM4djwpAy5Ip40aYCxz7ZMW84yQhZ4EhsyNPmDJsgMNnriyYiQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "ua-parser-js": "^1.0.37"
-      }
-    },
     "node_modules/@m-lab/ndt7": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@m-lab/ndt7/-/ndt7-0.1.4.tgz",
@@ -624,32 +614,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/ua-parser-js": {
-      "version": "1.0.41",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.41.tgz",
-      "integrity": "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "ua-parser-js": "script/cli.js"
-      },
-      "engines": {
-        "node": "*"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "build": "node scripts/build.js"
   },
   "dependencies": {
-    "@m-lab/msak": "^0.3.2",
     "@m-lab/ndt7": "0.1.4",
     "@sentry/browser": "^10.59.0"
   },

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -98,10 +98,6 @@ function build() {
   copyFile(path.join(ndt7Pkg, 'ndt7-upload-worker.js'), path.join(libDest, 'ndt7-upload-worker.js'));
   copyFile(path.join(ndt7Pkg, 'ndt7-download-worker.js'), path.join(libDest, 'ndt7-download-worker.js'));
 
-  // msak (uses dist/ folder)
-  const msakPkg = path.join(NODE_MODULES, '@m-lab', 'msak', 'dist');
-  copyFile(path.join(msakPkg, 'msak.min.js'), path.join(libDest, 'msak.min.js'));
-
   // Bundle Sentry SDK
   console.log('Bundling Sentry SDK...');
   const esbuild = require('esbuild');

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -53,7 +53,7 @@ table.transparent tbody tr:nth-child(2n + 1) {
     padding: 3em 2em 1em 2em;
     width: auto;
   }
-  span.privacyConsentMessage {
+  .privacyConsentMessage {
     display: none;
   }
 }
@@ -116,9 +116,14 @@ canvas.progressGauge {
   }
 }
 
-span.privacyConsentMessage {
+.privacyConsentMessage {
   font-size: small;
   color: rgba(255, 255, 255, 1.0);
+}
+
+.speedtestNotes > * {
+  display: block;
+  margin-top: 1em;
 }
 
 /* ============================================

--- a/src/index.html
+++ b/src/index.html
@@ -42,20 +42,16 @@
               <input type="checkbox" id="privacyConsent" name="privacyConsent">
               <label for="privacyConsent" style="font-size: smaller;" data-i18n data-i18n-html>I agree to the <a href="https://www.measurementlab.net/privacy/">data policy</a>, which includes retention and publication of IP addresses.</label>
             </p>
-            <div class="row">
-              <div class="col-6">
-                <a id="startButton" class="button special startButton big disabled">
-                  <span class="btn-begin"><span data-i18n>Begin</span> <i class="fa fa-play" aria-hidden="true"></i></span>
-                  <span class="btn-again" style="display:none;"><span data-i18n>Again</span> <i class="fa fa-repeat" aria-hidden="true"></i></span>
-                  <span class="btn-testing" style="display:none;"><span data-i18n>Testing</span> <i class="fa fa-circle-o-notch fa-spin" aria-hidden="true"></i></span>
-                </a>
-              </div>
-              <div class="col-6">
-                <span id="privacyMessage" data-i18n class="privacyConsentMessage">Please agree to the data policy prior to the test.</span>
-              </div>
+            <a id="startButton" class="button special startButton big disabled">
+              <span class="btn-begin"><span data-i18n>Begin</span> <i class="fa fa-play" aria-hidden="true"></i></span>
+              <span class="btn-again" style="display:none;"><span data-i18n>Again</span> <i class="fa fa-repeat" aria-hidden="true"></i></span>
+              <span class="btn-testing" style="display:none;"><span data-i18n>Testing</span> <i class="fa fa-circle-o-notch fa-spin" aria-hidden="true"></i></span>
+            </a>
+            <div class="speedtestNotes">
+              <div id="privacyMessage" data-i18n class="privacyConsentMessage">Please agree to the data policy prior to the test.</div>
+              <small style="font-style: italic;" data-i18n>We are temporarily running multiple tests back to back to calibrate new measurement protocols. This means results may take a little longer to appear than usual. Thank you for your help.</small>
+              <small data-i18n data-i18n-html>For more on M-Lab's data collection and measurement, including the disclosure of IP addresses, see our <a href="https://www.measurementlab.net/privacy/">Privacy Policy</a>.</small>
             </div>
-            <small style="font-style: italic;" data-i18n>We are temporarily running multiple tests back to back to calibrate new measurement protocols. This means results may take a little longer to appear than usual. Thank you for your help.</small><br /><br />
-            <small data-i18n data-i18n-html>For more on M-Lab's data collection and measurement, including the disclosure of IP addresses, see our <a href="https://www.measurementlab.net/privacy/">Privacy Policy</a>.</small>
           </section>
           <section id="measurementSpace">
             <div id="progressSection">

--- a/src/index.html
+++ b/src/index.html
@@ -49,7 +49,6 @@
             </a>
             <div class="speedtestNotes">
               <div id="privacyMessage" data-i18n class="privacyConsentMessage">Please agree to the data policy prior to the test.</div>
-              <small style="font-style: italic;" data-i18n>We are temporarily running multiple tests back to back to calibrate new measurement protocols. This means results may take a little longer to appear than usual. Thank you for your help.</small>
               <small data-i18n data-i18n-html>For more on M-Lab's data collection and measurement, including the disclosure of IP addresses, see our <a href="https://www.measurementlab.net/privacy/">Privacy Policy</a>.</small>
             </div>
           </section>
@@ -72,37 +71,31 @@
                     <td></td>
                     <td></td>
                     <td>NDT <a class="fa fa-question-circle" href="https://www.measurementlab.net/tests/ndt/" target="_blank"></a></td>
-                    <td>MSAK <a class="fa fa-question-circle" href="https://www.measurementlab.net/tests/msak/" target="_blank"></a></td>
                   </tr>
                   <tr>
                     <td><i class="fa fa-server" aria-hidden="true"></i></td>
                     <td data-i18n>Test Server</td>
                     <td><strong id="ndtLocation"></strong></td>
-                    <td><strong id="msakLocation"></strong></td>
                   </tr>
                   <tr>
                     <td><i class="fa fa-download" aria-hidden="true"></i></td>
                     <td data-i18n>Download</td>
                     <td><strong id="s2cRate"></strong></td>
-                    <td><strong id="msakDownload"></strong></td>
                   </tr>
                   <tr>
                     <td><i class="fa fa-upload" aria-hidden="true"></i></td>
                     <td data-i18n>Upload</td>
                     <td><strong id="c2sRate"></strong></td>
-                    <td><strong id="msakUpload"></strong></td>
                   </tr>
                   <tr>
                     <td><i class="fa fa-hourglass-start" aria-hidden="true"></i></td>
                     <td data-i18n>Latency</td>
                     <td><strong id="latency"></strong></td>
-                    <td><strong id="msakLatency"></strong></td>
                   </tr>
                   <tr>
                     <td><i class="fa fa-signal" aria-hidden="true"></i></td>
                     <td data-i18n>Retransmission</td>
                     <td><strong id="loss"></strong></td>
-                    <td><strong id="msakLoss"></strong></td>
                   </tr>
                 </tbody>
               </table>
@@ -203,7 +196,6 @@
     <!-- Scripts -->
     <script src="js/sentry.bundle.js"></script>
     <script src="libraries/ndt7.js"></script>
-    <script src="libraries/msak.min.js"></script>
 
     <script src="js/env.js"></script>
     <script src="js/i18n.js"></script>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -107,7 +107,7 @@ const SpeedTest = {
     }
 
     // Show/hide privacy message
-    this.els.privacyMessage.style.display = this.privacyConsent ? 'none' : 'inline';
+    this.els.privacyMessage.style.display = this.privacyConsent ? 'none' : 'block';
 
     // Show/hide progress vs results
     this.els.progressSection.style.display = this.measurementComplete ? 'none' : 'block';

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -10,7 +10,6 @@ const SpeedTest = {
   privacyConsent: false,
   measurementComplete: false,
   measurementResult: {},
-  msakResult: {},
 
   // DOM elements (cached on init)
   els: {},
@@ -38,15 +37,10 @@ const SpeedTest = {
 
       // Results
       location: document.getElementById('ndtLocation'),
-      msakLocation: document.getElementById('msakLocation'),
       s2cRate: document.getElementById('s2cRate'),
       c2sRate: document.getElementById('c2sRate'),
       latency: document.getElementById('latency'),
       loss: document.getElementById('loss'),
-      msakDownload: document.getElementById('msakDownload'),
-      msakUpload: document.getElementById('msakUpload'),
-      msakLatency: document.getElementById('msakLatency'),
-      msakLoss: document.getElementById('msakLoss'),
     };
 
     // Bind events
@@ -123,7 +117,6 @@ const SpeedTest = {
     this.testRunning = true;
     this.measurementComplete = false;
     this.measurementResult = {};
-    this.msakResult = {};
     this.updateUI();
 
     // Scroll to measurement area on mobile
@@ -137,15 +130,9 @@ const SpeedTest = {
     // Generate a random UUID
     const sessionID = crypto.randomUUID();
 
-    // Randomly choose which test to start first
+    // Execute ndt7
     try {
-      if (Math.random() < 0.5) {
-        await this.runNdt7(sessionID);
-        await this.runMSAK(sessionID);
-      } else {
-        await this.runMSAK(sessionID);
-        await this.runNdt7(sessionID);
-      }
+      await this.runNdt7(sessionID);
       this.els.currentPhase.textContent = i18n.t('Complete');
       this.els.currentSpeed.textContent = '';
       this.measurementComplete = true;
@@ -287,56 +274,6 @@ const SpeedTest = {
       },
     );
   },
-
-  async runMSAK(sid) {
-    const client = new msak.Client('speed-measurementlab-net', '1.1.0', {
-      onError: (err) => {
-        console.error('[msak] error:', err);
-        if (window.Sentry) Sentry.captureException(err, { tags: { test: 'msak' } });
-      },
-      onDownloadStart: (server) => {
-        console.log('[msak] Server: ' + server.machine);
-        this.els.msakLocation.textContent = server.location.city + ', ' + server.location.country;
-      },
-      onDownloadResult: (result) => {
-        this.msakResult.download = result.goodput.toFixed(2) + ' Mb/s';
-        this.els.msakDownload.textContent = this.msakResult.download;
-        if (result.retransmission != null && !isNaN(result.retransmission)) {
-          this.msakResult.loss = (result.retransmission * 100).toFixed(2) + '%';
-          this.els.msakLoss.textContent = this.msakResult.loss;
-        }
-        if (result.minRTT != null) {
-          this.msakResult.latency = (result.minRTT / 1000).toFixed(0) + ' ms';
-          this.els.msakLatency.textContent = this.msakResult.latency;
-        }
-        this.els.currentPhase.textContent = i18n.t('Download');
-        this.els.currentSpeed.textContent = result.goodput.toFixed(2) + ' Mb/s';
-        const progress = (result.elapsed > this.TIME_EXPECTED) ? 0.5 :
-          result.elapsed / (this.TIME_EXPECTED * 2);
-        ProgressGauge.progress(progress);
-      },
-      onUploadResult: (result) => {
-        this.msakResult.upload = result.goodput.toFixed(2) + ' Mb/s';
-        this.els.currentPhase.textContent = i18n.t('Upload');
-        this.els.currentSpeed.textContent = result.goodput.toFixed(2) + ' Mb/s';
-        this.els.msakUpload.textContent = this.msakResult.upload;
-        const progress = (result.elapsed > this.TIME_EXPECTED) ? 1.0 :
-          result.elapsed / (this.TIME_EXPECTED * 2) + 0.5;
-        ProgressGauge.progress(progress);
-      }
-    });
-
-    client.metadata = {
-      client_session_id: sid
-    };
-    // TODO(https://github.com/m-lab/mlab-speedtest/issues/77)
-    client.cc = 'cubic';
-    client.duration = 10000; // 10s
-    client.streams = 2;
-    client.debug = true;
-
-    await client.start();
-  }
 };
 
 // Initialize on DOM ready


### PR DESCRIPTION
Discussed with @robertodauria recently and right after I merged the https://github.com/m-lab/mlab-speedtest/pull/219 PR.

We probably have enough data at this stage and the calibration has been running for too much time anyway.

When facing the choice between partially disabling MSAK and completely removing it, I chose the latter under the reasoning that we can always reintroduce it later on by inspecting the git repository history, and complete removal avoids bitrot.

The related issue is https://github.com/m-lab/mlab-speedtest/issues/77.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-speedtest/222)
<!-- Reviewable:end -->
