### PR TITLE
fix: force false privacy checked-state on reload

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -65,6 +65,11 @@ const SpeedTest = {
     }, { rootMargin: '-45% 0px -45% 0px', threshold: 0 });
 
     sections.forEach(section => observer.observe(section));
+
+    // Force a known-good UI state on init: browsers may restore form
+    // values or cached display styles without firing change events.
+    this.els.privacyCheckbox.checked = false;
+    this.updateUI();
   },
 
   onPrivacyChange() {


### PR DESCRIPTION
With firefox, when I reload the webpage, if the privacy checkbox was already checked, it stays checked. This seems to occur because browsers, in general, may restore part of the previous UI state when reloading the webpage.

This diff fixes the immediate issue by forcing the checked state to false and calling `updateUI` to establish the known-good display state (that is, view state) based on the JS model.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-speedtest/223)
<!-- Reviewable:end -->
