### PR TITLE
fix: clear result fields on re-run to avoid stale values (#197)

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -113,6 +113,17 @@ const SpeedTest = {
     this.els.resultsSection.style.display = this.measurementComplete ? 'block' : 'none';
   },
 
+  /**
+   * Clear the displayed result fields so a re-run can't show stale
+   * values from a previous test if the current one fails partway.
+   */
+  clearResults() {
+    this.els.s2cRate.textContent = '';
+    this.els.c2sRate.textContent = '';
+    this.els.latency.textContent = '';
+    this.els.loss.textContent = '';
+  },
+
   async startTest() {
     if (!this.privacyConsent || this.testRunning) {
       return;
@@ -122,6 +133,7 @@ const SpeedTest = {
     this.testRunning = true;
     this.measurementComplete = false;
     this.measurementResult = {};
+    this.clearResults();
     this.updateUI();
 
     // Scroll to measurement area on mobile


### PR DESCRIPTION
`startTest()` reset the internal JS state (`this.measurementResult`) but never
cleared the result fields in the DOM. If a re-run failed partway (e.g. ndt7's
download phase succeeded but upload threw), the failed field kept showing the
previous run's value.

This adds a `clearResults()` helper that blanks `s2cRate`, `c2sRate`, `latency`,
and `loss` at the start of each run, back to their initial empty state.

fixes #197

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-speedtest/226)
<!-- Reviewable:end -->
